### PR TITLE
feat(knowledge): import from local path + base source tracking + UI fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ lib/
 *.tgz
 .DS_Store
 coverage/
+npm-cache/
+pack/

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,4 @@ allowBuilds:
   onnxruntime-node: true
   protobufjs: true
   sharp: true
-  tesseract.js: false
+  tesseract.js: true

--- a/src/knowledge/embed.ts
+++ b/src/knowledge/embed.ts
@@ -87,9 +87,13 @@ export async function embedTexts(
     // waiting immediately while the isolated worker finishes its current job.
     return await withAbortSignal(embedLocal(model.trim() === '' ? DEFAULT_LOCAL_MODEL : model, texts), signal)
   }
-  if (baseUrl.trim() === '') throw new Error('embedding base URL is empty')
   if (model.trim() === '') throw new Error('embedding model is empty')
-  if (provider === 'openai') return embedOpenAI(baseUrl, model, apiKey, texts, signal)
+  if (provider === 'openai') {
+    if (baseUrl.trim() === '') throw new Error('embedding base URL is empty')
+    return embedOpenAI(baseUrl, model, apiKey, texts, signal)
+  }
+  // Ollama defaults an empty base URL to the well-known local endpoint, so a
+  // base with an unset URL still embeds against http://127.0.0.1:11434.
   if (provider === 'ollama') return embedOllama(baseUrl, model, apiKey, texts, signal)
   throw new Error(`unknown embedding provider ${String(provider)}`)
 }
@@ -503,7 +507,7 @@ async function embedOllama(
   texts: readonly string[],
   signal?: AbortSignal,
 ): Promise<number[][]> {
-  const base = trimBase(baseUrl)
+  const base = trimBase(baseUrl.trim() === '' ? 'http://127.0.0.1:11434' : baseUrl)
   // Modern Ollama: POST /api/embed { model, input: [..] } -> { embeddings: [[..]] }
   const response = await httpFetch(`${base}/api/embed`, {
     method: 'POST',

--- a/src/knowledge/http.ts
+++ b/src/knowledge/http.ts
@@ -308,6 +308,12 @@ async function route(
       if (segments[2] === 'import-directory-tree' && method === 'POST') {
         return service.importDirectoryTree(baseId, typeof body.path === 'string' ? body.path : '')
       }
+      if (segments[2] === 'import-path' && method === 'POST') {
+        return service.importFromPath(baseId, typeof body.path === 'string' ? body.path : '')
+      }
+      if (segments[2] === 'source-path' && method === 'POST') {
+        return service.setBaseSourcePath(baseId, typeof body.path === 'string' ? body.path : '')
+      }
       if (segments[2] === 'directories' && method === 'POST') {
         return service.createDirectory(
           baseId,

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -58,6 +58,7 @@ import type {
   AddFilesResult,
   AddTextDocumentRequest,
   BaseConfig,
+  BaseSourceInfo,
   BaseStats,
   BaseSummary,
   CreateBaseRequest,
@@ -664,16 +665,20 @@ export class KnowledgeService extends Service {
       const chunkCount = documents.reduce((sum, doc) => sum + doc.chunkCount, 0)
       const charCount = documents.reduce((sum, doc) => sum + doc.charCount, 0)
       const tokenCount = documents.reduce((sum, doc) => sum + (doc.tokenCount ?? 0), 0)
+      const storedDocCount = documents.reduce((sum, doc) => sum + (doc.rawFilePath !== undefined ? 1 : 0), 0)
+      const sourceInfo = baseSourceLines(documents)
       return {
         id: base.id,
         name: base.name,
         description: base.description,
         ...(base.group !== undefined ? { group: base.group } : {}),
         documentCount: documents.length,
+        storedDocCount,
         chunkCount,
         charCount,
         tokenCount,
         ...(base.config !== undefined ? { config: base.config } : {}),
+        ...(sourceInfo.length > 0 ? { sourceInfo } : {}),
         createdAt: base.createdAt,
         updatedAt: base.updatedAt,
       }
@@ -1035,14 +1040,21 @@ export class KnowledgeService extends Service {
         if (store.raw !== undefined) {
           rawFilePath = await store.raw.writeRel(job.baseId, basename(file), buffer)
         }
-        await this.ingestDocument({
-          baseId: job.baseId,
-          title: basename(file),
-          sourceType: 'file',
-          fileName: basename(file),
-          rawFilePath,
-          text,
-        })
+        try {
+          await this.ingestDocument({
+            baseId: job.baseId,
+            title: basename(file),
+            sourceType: 'file',
+            fileName: basename(file),
+            rawFilePath,
+            text,
+          })
+        } catch (error) {
+          // A rejected item (e.g. duplicate content) must not leave an
+          // orphaned raw copy behind.
+          if (rawFilePath !== undefined) await store.raw?.delete(rawFilePath)
+          throw error
+        }
         job.imported += 1
       } catch (error) {
         job.errors.push({ file, error: error instanceof Error ? error.message : String(error) })
@@ -1127,15 +1139,22 @@ export class KnowledgeService extends Service {
               const relPath = relative(path, full).replace(/\\/g, '/')
               rawFilePath = await store.raw.writeRel(baseId, relPath, buffer)
             }
-            await this.ingestDocument({
-              baseId,
-              title: basename(full),
-              sourceType: 'file',
-              fileName: basename(full),
-              parentDirectoryId: parentId,
-              rawFilePath,
-              text,
-            })
+            try {
+              await this.ingestDocument({
+                baseId,
+                title: basename(full),
+                sourceType: 'file',
+                fileName: basename(full),
+                parentDirectoryId: parentId,
+                rawFilePath,
+                text,
+              })
+            } catch (error) {
+              // A rejected item (e.g. duplicate content) must not leave an
+              // orphaned raw copy behind.
+              if (rawFilePath !== undefined) await store.raw?.delete(rawFilePath)
+              throw error
+            }
             imported += 1
           } catch (error) {
             errors.push({ file: full, error: error instanceof Error ? error.message : String(error) })
@@ -1146,6 +1165,103 @@ export class KnowledgeService extends Service {
 
     await walk(path, rootId, 0)
     return { imported, directories, errors }
+  }
+
+  /** Import a single local file by its absolute path (server-side). */
+  async importFileFromPath(baseId: string, filePath: string): Promise<{ imported: boolean; title: string }> {
+    const store = this.requireStore()
+    if (store.getBase(baseId) === undefined) throw new Error(`knowledge base not found: ${baseId}`)
+    const name = basename(filePath)
+    if (!SUPPORTED_DOCUMENT_EXTENSION_SET.has(extensionOf(name))) {
+      throw new Error(`Unsupported knowledge file type: ${name}`)
+    }
+    const buffer = await readFile(filePath)
+    const text = await parseDocumentBuffer(buffer, name)
+    if (text.trim().length === 0) throw new Error(`file is empty or unreadable: ${filePath}`)
+    // Persist a stable raw copy (Cherry's "import means copy") so the base
+    // stays rebuildable even if the source file changes or disappears.
+    let rawFilePath: string | undefined
+    if (store.raw !== undefined) {
+      rawFilePath = await store.raw.writeRel(baseId, name, buffer)
+    }
+    try {
+      await this.ingestDocument({
+        baseId,
+        title: name,
+        sourceType: 'file',
+        fileName: name,
+        rawFilePath,
+        sourcePath: filePath,
+        text,
+      })
+    } catch (error) {
+      // A rejected item (e.g. duplicate content) must not leave an orphaned
+      // raw copy behind.
+      if (rawFilePath !== undefined) await store.raw?.delete(rawFilePath)
+      throw error
+    }
+    return { imported: true, title: name }
+  }
+
+  /**
+   * Import a local path (directory tree or single file) by its absolute path,
+   * validating that it exists first. Directories reuse the tree import, which
+   * records `sourcePath` on every container so reindex rescans the disk.
+   */
+  async importFromPath(baseId: string, path: string): Promise<{ kind: 'directory' | 'file'; imported: number }> {
+    const trimmed = path.trim()
+    if (trimmed.length === 0) throw new Error('path is required')
+    let st
+    try {
+      st = await stat(trimmed)
+    } catch {
+      throw new Error(`path not found: ${trimmed}`)
+    }
+    if (st.isDirectory()) {
+      const result = await this.importDirectoryTree(baseId, trimmed)
+      return { kind: 'directory', imported: result.imported }
+    }
+    if (st.isFile()) {
+      await this.importFileFromPath(baseId, trimmed)
+      return { kind: 'file', imported: 1 }
+    }
+    throw new Error(`not a file or directory: ${trimmed}`)
+  }
+
+  /**
+   * Repoint a base's source: set `sourcePath` on every top-level directory
+   * container (path must be an existing directory), or on every top-level file
+   * document (path must be an existing file) when the base has no directory
+   * root. Used by the pencil button next to the base's source line.
+   */
+  async setBaseSourcePath(baseId: string, path: string): Promise<{ set: number }> {
+    const store = this.requireStore()
+    if (store.getBase(baseId) === undefined) throw new Error(`knowledge base not found: ${baseId}`)
+    const trimmed = path.trim()
+    if (trimmed.length === 0) throw new Error('path is required')
+    let st
+    try {
+      st = await stat(trimmed)
+    } catch {
+      throw new Error(`path not found: ${trimmed}`)
+    }
+    const roots = store.listDocuments(baseId).filter(doc => doc.parentDirectoryId === undefined)
+    const dirRoots = roots.filter(doc => doc.sourceType === 'directory')
+    const fileRoots = roots.filter(doc => doc.sourceType === 'file')
+    let targets: KnowledgeDocument[]
+    if (dirRoots.length > 0) {
+      if (!st.isDirectory()) throw new Error(`not a directory: ${trimmed}`)
+      targets = dirRoots
+    } else if (fileRoots.length > 0) {
+      if (!st.isFile()) throw new Error(`not a file: ${trimmed}`)
+      targets = fileRoots
+    } else {
+      throw new Error('base has no directory or file source to repoint')
+    }
+    for (const doc of targets) {
+      await store.putDocument({ ...doc, sourcePath: trimmed, updatedAt: Date.now() })
+    }
+    return { set: targets.length }
   }
 
   async addUrlDocument(request: ImportUrlRequest): Promise<KnowledgeDocument> {
@@ -1385,7 +1501,9 @@ export class KnowledgeService extends Service {
    * - files/directories removed from disk are deleted from the base,
    * - new supported files are parsed and ingested (raw copy persisted),
    * - new subdirectories become containers (with their own sourcePath),
-   * - existing items are re-indexed (re-chunk + hash-reuse re-embed).
+   * - existing items are re-indexed (re-chunk + hash-reuse re-embed); when
+   *   the on-disk bytes differ from the base's persisted raw copy, the copy
+   *   is refreshed first so EDITS to source files are picked up too.
    * A missing/unreadable source keeps the existing subtree untouched (Cherry
    * skips roots whose source cannot be rebuilt). Failures are isolated per
    * entry and summarized at the end.
@@ -1464,6 +1582,42 @@ export class KnowledgeService extends Service {
         try {
           if (existing !== undefined) {
             if (this.indexing.has(existing.id)) continue
+            // Content sync with the disk: reindex alone rebuilds from the
+            // base's persisted raw copy, so edits to a source file were never
+            // picked up. When the on-disk bytes differ from the stored copy,
+            // refresh the copy and re-index from the NEW content. Equal bytes
+            // fall through to the plain reindex (rebuild from the stored
+            // copy); a failed disk read must never wipe the stored copy or
+            // the existing vectors, so it also falls through unchanged.
+            if (store.raw !== undefined && existing.rawFilePath !== undefined) {
+              try {
+                const buffer = await readFile(full)
+                const stored = await store.raw.read(existing.rawFilePath)
+                const changed = stored === null || stored === undefined || stored.byteLength === 0
+                  || !Buffer.from(stored).equals(buffer)
+                if (changed) {
+                  const text = await parseDocumentBuffer(buffer, entry.name)
+                  // Never replace a good snapshot with empty/unreadable new
+                  // content: keep the stored copy and the old vectors.
+                  if (text.trim().length > 0) {
+                    // rawFilePath already carries the `<baseId>/` prefix (it is
+                    // the full base-relative path), so strip it before writeRel,
+                    // which prepends `<baseId>/` again — otherwise the refreshed
+                    // bytes land at a doubled path and the following reindex still
+                    // rebuilds from the stale stored copy.
+                    const relRaw = existing.rawFilePath.startsWith(`${document.baseId}/`)
+                      ? existing.rawFilePath.slice(document.baseId.length + 1)
+                      : existing.rawFilePath
+                    await store.raw.writeRel(document.baseId, relRaw, buffer)
+                    await this.reindexDocument(existing.id)
+                    continue
+                  }
+                }
+              } catch {
+                // Disk or raw read failed: fall back to the stored-copy
+                // reindex below (the copy and vectors stay intact).
+              }
+            }
             await this.reindexDocument(existing.id)
           } else {
             // New file: parse + ingest like an import, with a persisted raw
@@ -1484,15 +1638,22 @@ export class KnowledgeService extends Service {
               }
               const relPath = relative(root.sourcePath ?? source, full).replace(/\\/g, '/')
               rawFilePath = await store.raw.writeRel(document.baseId, relPath, buffer)
-              await this.ingestDocument({
-                baseId: document.baseId,
-                title: entry.name,
-                sourceType: 'file',
-                fileName: entry.name,
-                parentDirectoryId: document.id,
-                rawFilePath,
-                text,
-              })
+              try {
+                await this.ingestDocument({
+                  baseId: document.baseId,
+                  title: entry.name,
+                  sourceType: 'file',
+                  fileName: entry.name,
+                  parentDirectoryId: document.id,
+                  rawFilePath,
+                  text,
+                })
+              } catch (error) {
+                // A rejected item (e.g. duplicate content) must not leave an
+                // orphaned raw copy behind.
+                await store.raw.delete(rawFilePath)
+                throw error
+              }
             } else {
               await this.ingestDocument({
                 baseId: document.baseId,
@@ -2213,6 +2374,7 @@ export class KnowledgeService extends Service {
     return {
       ...(baseId !== undefined ? { baseId } : {}),
       documentCount: documents.length,
+      storedDocCount: documents.reduce((sum, doc) => sum + (doc.rawFilePath !== undefined ? 1 : 0), 0),
       chunkCount: chunkStats.count,
       charCount,
       tokenCount,
@@ -2747,6 +2909,8 @@ export class KnowledgeService extends Service {
     text: string
     /** Base-relative path of the persisted original source bytes (file docs). */
     rawFilePath?: string
+    /** Absolute source path the item was imported from (file/path imports). */
+    sourcePath?: string
     /** Pre-created placeholder id (already stored, shown while embedding). */
     placeholderId?: string
   }, signal?: AbortSignal): Promise<KnowledgeDocument> {
@@ -2791,6 +2955,7 @@ export class KnowledgeService extends Service {
         ...(input.url !== undefined ? { url: input.url } : {}),
         ...(input.parentDirectoryId !== undefined ? { parentDirectoryId: input.parentDirectoryId } : {}),
         ...(input.rawFilePath !== undefined ? { rawFilePath: input.rawFilePath } : {}),
+        ...(input.sourcePath !== undefined ? { sourcePath: input.sourcePath } : {}),
         contentHash,
         rawText: input.text,
         charCount: input.text.length,
@@ -3069,6 +3234,39 @@ function effectiveMode(requested: SearchMode, ranked: readonly RankedHit[]): Sea
   if (requested === 'hybrid') return hybrid ? 'hybrid' : 'lexical'
   // auto
   return hybrid ? 'hybrid' : 'lexical'
+}
+
+/** Bounded list of a base's top-level sources (directory roots / files / URLs /
+ *  text nodes), for the detail header. Nested children are covered by their
+ *  root, so only `parentDirectoryId === undefined` items are listed. */
+function baseSourceLines(documents: KnowledgeDocument[]): BaseSourceInfo[] {
+  const MAX = 4
+  const seen = new Set<string>()
+  const lines: BaseSourceInfo[] = []
+  for (const doc of documents) {
+    if (doc.parentDirectoryId !== undefined) continue
+    let kind: DocumentSourceType
+    let text: string
+    if (doc.sourceType === 'directory') {
+      kind = 'directory'
+      text = doc.sourcePath ?? doc.title
+    } else if (doc.sourceType === 'url') {
+      kind = 'url'
+      text = doc.url ?? doc.title
+    } else if (doc.sourceType === 'file') {
+      kind = 'file'
+      text = doc.sourcePath ?? doc.fileName ?? doc.title
+    } else {
+      kind = 'text'
+      text = 'node'
+    }
+    const key = `${kind}:${text}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    lines.push({ kind, text })
+    if (lines.length >= MAX) break
+  }
+  return lines
 }
 
 function sha256(text: string): string {

--- a/src/knowledge/store.ts
+++ b/src/knowledge/store.ts
@@ -10,8 +10,8 @@
  */
 
 import type { Domain, DomainSpec } from '@deepseek-ai/dsh-storage-domain'
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { dirname, extname, join } from 'node:path'
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { dirname, extname, join, relative } from 'node:path'
 import { knowledgeDomainSpec, TABLES } from './domain.js'
 import type { ConfigOverrides } from './domain.js'
 import { ChunkDatabase, hashEmbeddingText, legacyChunkFilePath, migrateLegacyChunkFile, resolveChunkStorePath, searchTextOf } from './chunkdb.js'
@@ -47,6 +47,8 @@ export interface RawFileStore {
   writeRel(baseId: string, relativePath: string, bytes: Uint8Array): Promise<string>
   /** Read a document's source bytes back (null when absent). */
   read(relativePath: string): Promise<Uint8Array | null>
+  /** Every stored base-relative path (for orphan-raw reconciliation). */
+  listAll(): Promise<string[]>
   /** Remove one document's source file by its stored relative path (missing = no-op). */
   delete(relativePath: string): Promise<void>
   /** Remove every source file of a base. */
@@ -90,6 +92,25 @@ export class RawFileStorage implements RawFileStore {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
       throw error
     }
+  }
+
+  async listAll(): Promise<string[]> {
+    const out: string[] = []
+    const walk = async (dir: string): Promise<void> => {
+      let entries
+      try {
+        entries = await readdir(dir, { withFileTypes: true })
+      } catch {
+        return
+      }
+      for (const entry of entries) {
+        const full = join(dir, entry.name)
+        if (entry.isDirectory()) await walk(full)
+        else out.push(relative(this.root, full).replace(/\\/g, '/'))
+      }
+    }
+    await walk(this.root)
+    return out
   }
 
   async delete(relativePath: string): Promise<void> {
@@ -153,6 +174,8 @@ export interface Store {
    *   before/during parse) — re-indexed by the service after startup.
    */
   recoverInterruptedImports(startedAt: number): Promise<{ removed: number; resume: string[] }>
+  /** Remove raw source copies no document references (orphans from failed/duplicate imports). */
+  reconcileOrphanRaws(): Promise<number>
   /** Aggregate chunk stats without loading chunk rows. */
   chunkStats(baseIds: readonly string[]): ChunkStats
   /** SQL-backed retrieval lanes (FTS5 + vector scan); absent on in-memory stores. */
@@ -220,6 +243,8 @@ export async function openStore(
       const recovery = await store.recoverInterruptedImports(Date.now())
       if (recovery.removed > 0) console.warn(`dsh-knowledge: removed ${recovery.removed} incomplete import(s) left by an interrupted run`)
       await store.reconcileChunkCounts()
+      const orphaned = await store.reconcileOrphanRaws()
+      if (orphaned > 0) console.warn(`dsh-knowledge: removed ${orphaned} orphaned raw source file(s) no document referenced`)
       return store
     } catch (error) {
       // Fall through to memory on any open failure (no backend, version mismatch, …).
@@ -379,6 +404,23 @@ class DomainStore implements Store {
 
   docChunkStatus(baseId: string): { withChunks: Set<string>; missingEmbedding: Set<string> } {
     return this.chunkDb.docChunkStatus(baseId)
+  }
+
+  async reconcileOrphanRaws(): Promise<number> {
+    const referenced = new Set<string>()
+    for (const base of this.listBases()) {
+      for (const doc of this.listDocuments(base.id)) {
+        if (doc.rawFilePath !== undefined) referenced.add(doc.rawFilePath)
+      }
+    }
+    let removed = 0
+    for (const rel of await this.rawStore.listAll()) {
+      if (!referenced.has(rel)) {
+        await this.rawStore.delete(rel)
+        removed += 1
+      }
+    }
+    return removed
   }
 
   chunkStats(baseIds: readonly string[]): ChunkStats {
@@ -591,6 +633,11 @@ class MemoryStore implements Store {
       removed += 1
     }
     return { removed, resume }
+  }
+
+  async reconcileOrphanRaws(): Promise<number> {
+    // In-memory store keeps no raw files on disk.
+    return 0
   }
 
   docChunkStatus(baseId: string): { withChunks: Set<string>; missingEmbedding: Set<string> } {

--- a/src/knowledge/types.ts
+++ b/src/knowledge/types.ts
@@ -315,6 +315,15 @@ export interface DocumentSummary {
   readonly updatedAt?: number
 }
 
+/** One origin line for a base: where its content came from (shown under the
+ *  base name in the detail header — path for directories/files, link for URLs,
+ *  "node" for manually added text). */
+export interface BaseSourceInfo {
+  readonly kind: DocumentSourceType
+  /** Directory path / file name / URL / 'node'. */
+  readonly text: string
+}
+
 /** Summary of one knowledge base, for listing UIs. */
 export interface BaseSummary {
   readonly id: string
@@ -322,10 +331,14 @@ export interface BaseSummary {
   readonly description: string
   readonly group?: string
   readonly documentCount: number
+  /** Documents with a persisted raw source copy (actually imported & stored). */
+  readonly storedDocCount: number
   readonly chunkCount: number
   readonly charCount: number
   readonly tokenCount: number
   readonly config?: BaseConfig
+  /** Top-level sources of the base's content, for display (bounded). */
+  readonly sourceInfo?: BaseSourceInfo[]
   readonly createdAt: number
   readonly updatedAt: number
 }
@@ -334,6 +347,8 @@ export interface BaseSummary {
 export interface BaseStats {
   readonly baseId?: string
   readonly documentCount: number
+  /** Documents with a persisted raw source copy (actually imported & stored). */
+  readonly storedDocCount: number
   readonly chunkCount: number
   readonly charCount: number
   readonly tokenCount: number

--- a/src/tool-knowledge/index.ts
+++ b/src/tool-knowledge/index.ts
@@ -50,11 +50,12 @@ const contextWindowSchema = {
 function aggregateStats(rows: ReadonlyArray<ReturnType<KnowledgeService['stats']>>): ReturnType<KnowledgeService['stats']> {
   return rows.reduce<ReturnType<KnowledgeService['stats']>>((total, row) => ({
     documentCount: total.documentCount + row.documentCount,
+    storedDocCount: total.storedDocCount + row.storedDocCount,
     chunkCount: total.chunkCount + row.chunkCount,
     charCount: total.charCount + row.charCount,
     tokenCount: total.tokenCount + row.tokenCount,
     embedded: total.embedded || row.embedded,
-  }), { documentCount: 0, chunkCount: 0, charCount: 0, tokenCount: 0, embedded: false })
+  }), { documentCount: 0, storedDocCount: 0, chunkCount: 0, charCount: 0, tokenCount: 0, embedded: false })
 }
 
 function clampToolInt(value: number | undefined, min: number, max: number, fallback: number): number {

--- a/src/ui/client/KnowledgeSection.tsx
+++ b/src/ui/client/KnowledgeSection.tsx
@@ -35,9 +35,12 @@ import {
 import {
   IconBook,
   IconCheck,
+  IconDoc,
   IconEye,
   IconFlask,
+  IconLink,
   IconMore,
+  IconPencil,
   IconPlus,
   IconRefresh,
   IconSearch,
@@ -139,6 +142,8 @@ type DialogState =
   | { kind: 'renameGroup'; group: string }
   | { kind: 'confirmDeleteGroup'; group: string }
   | { kind: 'addUrl' }
+  | { kind: 'addPath' }
+  | { kind: 'editSourcePath'; initial: string }
   | { kind: 'addText' }
   | null
 
@@ -193,6 +198,10 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
   const [localModelStatus, setLocalModelStatus] = useState<LocalModelStatus | null>(null)
   const [docLimit, setDocLimit] = useState(100)
   const [navWidth, setNavWidth] = useState(272)
+  // Sliding side panels (settings / recall test) are resizable too; the width
+  // is shared between them so the user's preference sticks while the panel is
+  // open.
+  const [sidePanelWidth, setSidePanelWidth] = useState(460)
   const [dragOver, setDragOver] = useState(false)
   const dragDepth = useRef(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -210,9 +219,16 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
   const notify = useCallback((kind: Toast['kind'], text: string): void => {
     const id = Date.now() + Math.random()
     setToasts(prev => [...prev, { id, kind, text }])
+    // Errors/warnings carry codes the user may need to copy, so they stay
+    // until dismissed manually; success/info auto-clear after a short delay.
+    if (kind === 'error' || kind === 'warning') return
     window.setTimeout(() => {
       setToasts(prev => prev.filter(toast => toast.id !== id))
     }, 3200)
+  }, [])
+
+  const dismissToast = useCallback((id: number): void => {
+    setToasts(prev => prev.filter(toast => toast.id !== id))
   }, [])
 
   const run = useCallback(async (fn: () => Promise<void>): Promise<void> => {
@@ -261,6 +277,22 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
     document.addEventListener('mousemove', onMove)
     document.addEventListener('mouseup', onUp)
   }, [navWidth])
+
+  const onSideResizeStart = useCallback((event: React.MouseEvent): void => {
+    event.preventDefault()
+    const startX = event.clientX
+    const startWidth = sidePanelWidth
+    const onMove = (ev: MouseEvent): void => {
+      // Panel sits on the right edge; dragging left grows it, right shrinks.
+      setSidePanelWidth(Math.min(680, Math.max(360, startWidth - (ev.clientX - startX))))
+    }
+    const onUp = (): void => {
+      document.removeEventListener('mousemove', onMove)
+      document.removeEventListener('mouseup', onUp)
+    }
+    document.addEventListener('mousemove', onMove)
+    document.addEventListener('mouseup', onUp)
+  }, [sidePanelWidth])
 
   // Local embedding readiness, for the empty-state guidance.
   useEffect(() => {
@@ -511,6 +543,51 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
       }
     })
   }, [api, run, onImported, notify, selectedBaseId, currentDirectoryId])
+
+  const promptForPath = useCallback((): void => {
+    if (selectedBaseId === null) return
+    setDialog({ kind: 'addPath' })
+  }, [selectedBaseId])
+
+  const addPath = useCallback((path: string): void => {
+    if (selectedBaseId === null) return
+    const trimmed = path.trim()
+    if (trimmed === '') return
+    void run(async () => {
+      try {
+        const result = await api.importFromPath(selectedBaseId, trimmed)
+        setDialog(null)
+        notify('success', `${t('tabPath')}: ${result.kind === 'directory' ? `${result.imported} ${t('docCount')}` : result.imported}`)
+        await refreshBases()
+        await reloadDocuments()
+      } catch (err) {
+        notify('error', err instanceof Error ? err.message : String(err))
+      }
+    })
+  }, [api, run, refreshBases, reloadDocuments, notify, selectedBaseId, t])
+
+  const promptForSourcePath = useCallback((): void => {
+    if (selectedBaseId === null) return
+    const currentBase = bases.find(base => base.id === selectedBaseId)
+    const current = currentBase?.sourceInfo?.map(source => source.text).find(Boolean) ?? ''
+    setDialog({ kind: 'editSourcePath', initial: current })
+  }, [bases, selectedBaseId])
+
+  const editSourcePath = useCallback((path: string): void => {
+    if (selectedBaseId === null) return
+    const trimmed = path.trim()
+    if (trimmed === '') return
+    void run(async () => {
+      try {
+        const result = await api.setBaseSourcePath(selectedBaseId, trimmed)
+        setDialog(null)
+        notify('success', `${t('sourcePathEdit')}: ${result.set}`)
+        await refreshBases()
+      } catch (err) {
+        notify('error', err instanceof Error ? err.message : String(err))
+      }
+    })
+  }, [api, run, refreshBases, notify, selectedBaseId, t])
 
   const addText = useCallback((title: string, content: string): void => {
     if (selectedBaseId === null) return
@@ -895,7 +972,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
             apiKey: config.apiKey,
           })
         } catch (error) {
-          notify('error', `${t('dimensionProbeFailed')}：${error instanceof Error ? error.message : String(error)}`)
+          notify('error', `${t('dimensionProbeFailed')}: ${error instanceof Error ? error.message : String(error)}`)
           return
         }
       }
@@ -1047,6 +1124,15 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
     { key: 'delete', label: t('delete'), danger: true, onSelect: () => setDialog({ kind: 'confirmDeleteGroup', group }) },
   ]
 
+  const baseSourceGlyph = (kind: 'text' | 'file' | 'url' | 'directory'): JSX.Element => {
+    switch (kind) {
+      case 'directory': return <IconFolderOpen size={12} />
+      case 'url': return <IconLink size={12} />
+      case 'file': return <IconDoc size={12} />
+      default: return <IconPencil size={12} />
+    }
+  }
+
   const renderBaseRow = (base: BaseSummary): JSX.Element => (
     <div
       key={base.id}
@@ -1076,6 +1162,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
   const addSourceMenu: MenuEntry[] = [
     { key: 'file', label: t('tabFile'), onSelect: () => fileInputRef.current?.click() },
     { key: 'dir', label: t('tabDir'), onSelect: () => dirInputRef.current?.click() },
+    { key: 'path', label: t('tabPath'), onSelect: () => promptForPath() },
     { key: 'url', label: t('tabUrl'), onSelect: () => promptForUrl() },
     { key: 'text', label: t('tabText'), onSelect: () => setDialog({ kind: 'addText' }) },
   ]
@@ -1130,7 +1217,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
         </span>
       </div>
 
-      <Toasts toasts={toasts} />
+      <Toasts toasts={toasts} onDismiss={dismissToast} />
 
       <div style={style.body}>
         <aside style={{ ...style.sidebar, width: navWidth }} className="kb-scroll">
@@ -1188,9 +1275,11 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
         </aside>
 
         <div
+          className="kb-sash"
           onMouseDown={onNavResizeStart}
-          style={{ width: 5, cursor: 'col-resize', flexShrink: 0, background: 'transparent', borderRight: `1px solid ${C.border}` }}
+          style={{ width: 8, cursor: 'col-resize', flexShrink: 0, background: 'transparent', borderRight: `1px solid ${C.border}` }}
           title={t('dragResize')}
+          aria-label={t('dragResize')}
         />
 
         <main style={style.main} className="kb-scroll">
@@ -1249,6 +1338,29 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                 </span>
               </div>
 
+              {/* Base origin(s), between the name and the stats: directory
+                  path / file / URL / node for manually added text. The pencil
+                  repoints the base's source path (validated server-side). */}
+              {(selectedBase.sourceInfo ?? []).length > 0 && (
+                <div style={style.baseSourceRow}>
+                  {selectedBase.sourceInfo!.map((source, i) => (
+                    <span key={i} style={style.baseSourceItem}>
+                      <span style={style.baseSourceGlyph}>{baseSourceGlyph(source.kind)}</span>
+                      <span style={style.baseSourceText} title={source.text}>{source.text}</span>
+                    </span>
+                  ))}
+                  <button
+                    className="kb-iconbtn"
+                    style={{ ...style.baseSourceEdit, ...style.iconOnlyButton }}
+                    title={t('sourcePathEdit')}
+                    aria-label={t('sourcePathEdit')}
+                    onClick={promptForSourcePath}
+                  >
+                    <IconPencil size={11} />
+                  </button>
+                </div>
+              )}
+
               {selectedDocId !== null && selectedDoc !== null ? (
                 <DocumentDetailPanel
                   key={selectedDoc.id}
@@ -1265,7 +1377,8 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                 <>
                   {stats !== null && (
                     <div style={style.statsRow}>
-                      <StatChip value={stats.documentCount} label={t('statsDocs')} />
+                      <StatChip value={stats.documentCount} label={t('statsSourceDocs')} title={t('statsSourceDocsTitle')} />
+                      <StatChip value={stats.storedDocCount} label={t('statsStoredDocs')} title={t('statsStoredDocsTitle')} />
                       <StatChip value={stats.chunkCount} label={t('statsChunks')} />
                       <StatChip value={stats.tokenCount} label={t('statsTokens')} />
                       <StatChip value={formatSize(stats.charCount)} label={t('statsChars')} />
@@ -1300,7 +1413,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                         background: 'color-mix(in srgb, var(--dsw-alias-brand-primary, #3b6ef6) 8%, transparent)',
                         borderRadius: 10, pointerEvents: 'none',
                       }}>
-                        <span style={{ fontSize: 14, fontWeight: 600, color: C.accent, background: 'var(--dsw-bg-base, #fff)', padding: '8px 16px', borderRadius: 999, boxShadow: '0 2px 10px rgba(0,0,0,0.12)' }}>
+                        <span style={{ fontSize: 14, fontWeight: 600, color: C.accent, background: C.bg, padding: '8px 16px', borderRadius: 999, boxShadow: '0 2px 10px rgba(0,0,0,0.12)' }}>
                           {t('dragToUpload')}
                         </span>
                       </div>
@@ -1319,7 +1432,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                             <IconRefresh size={13} />{t('bulkReindex')}
                           </button>
                           <button
-                            style={style.primaryDanger}
+                            className="kb-danger-primary" style={style.primaryDanger}
                             disabled={busy}
                             onClick={() => setDialog({ kind: 'confirmBulkDelete', count: checkedDocs.length })}
                           >
@@ -1331,7 +1444,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                         <span style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
                           <span style={{ fontSize: 11, color: C.muted }}>
-                            {t('updatedAtText')} {formatRelativeTime(selectedBase.updatedAt)}
+                            {t('updatedAtText')} {formatRelativeTime(selectedBase.updatedAt, t)}
                           </span>
                           {selectedBaseLocalModel !== null && localModelStatus !== null && localModelStatus.status !== 'ready' && (
                             <span
@@ -1360,7 +1473,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                         </span>
                         <PopoverMenu
                           align="end"
-                          trigger={<button style={style.primary} disabled={busy}><IconPlus />{t('addSource')}</button>}
+                          trigger={<button className="kb-primary" style={style.primary} disabled={busy}><IconPlus />{t('addSource')}</button>}
                           entries={addSourceMenu}
                         />
                       </div>
@@ -1382,7 +1495,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                               <div style={{ display: 'flex', justifyContent: 'center' }}>
                                 <PopoverMenu
                                   align="start"
-                                  trigger={<button style={style.primary} disabled={busy}><IconPlus />{t('addSource')}</button>}
+                                  trigger={<button className="kb-primary" style={style.primary} disabled={busy}><IconPlus />{t('addSource')}</button>}
                                   entries={addSourceMenu}
                                 />
                               </div>
@@ -1547,7 +1660,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                                         style={{ display: 'inline-flex', alignItems: 'center', gap: 3, fontSize: 11, color: C.danger }}
                                         tabIndex={0}
                                         role="img"
-                                        aria-label={`${t('embeddingFailed')}：${reason}`}
+                                        aria-label={`${t('embeddingFailed')}: ${reason}`}
                                         title={reason}
                                       >
                                         ✕ {t('embeddingFailed')}
@@ -1564,7 +1677,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                                   )
                                 })()}
                                 <span style={{ fontSize: 11, color: C.muted }}>
-                                  {doc.updatedAt !== undefined ? formatRelativeTime(doc.updatedAt) : ''}
+                                  {doc.updatedAt !== undefined ? formatRelativeTime(doc.updatedAt, t) : ''}
                                 </span>
                                 <PopoverMenu
                                   align="end"
@@ -1576,7 +1689,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                             {hasMoreDocuments && (
                               <div style={{ display: 'flex', justifyContent: 'center', padding: '10px 0 4px' }}>
                                 <button className="kb-row" style={style.button} onClick={() => setDocLimit(v => v + 100)}>
-                                  {t('loadMore')}（{renderedDocuments.length}/{visibleDocuments.length}）
+                                  {t('loadMore')} ({renderedDocuments.length}/{visibleDocuments.length})
                                 </button>
                               </div>
                             )}
@@ -1595,7 +1708,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
         </main>
 
         {ragOpen && globalConfig !== null && selectedBase !== null && (
-          <SidePanel title={t('baseSettings')} onClose={() => setRagOpen(false)}>
+          <SidePanel title={t('baseSettings')} onClose={() => setRagOpen(false)} width={sidePanelWidth} onResizeWidth={onSideResizeStart}>
             <RagConfigPanel
               base={selectedBase}
               globalConfig={globalConfig}
@@ -1608,7 +1721,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
         )}
 
         {recallOpen && selectedBase !== null && (
-          <SidePanel title={t('recallTest')} onClose={() => setRecallOpen(false)}>
+          <SidePanel title={t('recallTest')} onClose={() => setRecallOpen(false)} width={sidePanelWidth} onResizeWidth={onSideResizeStart}>
             <RecallPanel
               t={t}
               busy={busy}
@@ -1722,6 +1835,24 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
           onClose={() => setDialog(null)}
         />
       )}
+      {dialog?.kind === 'addPath' && (
+        <PromptDialog
+          title={t('tabPath')}
+          label={t('pathDesc')}
+          initial=""
+          onOk={(value) => { setDialog(null); addPath(value) }}
+          onClose={() => setDialog(null)}
+        />
+      )}
+      {dialog?.kind === 'editSourcePath' && (
+        <PromptDialog
+          title={t('sourcePathEdit')}
+          label={t('sourcePathPrompt')}
+          initial={dialog.initial}
+          onOk={(value) => { setDialog(null); editSourcePath(value) }}
+          onClose={() => setDialog(null)}
+        />
+      )}
       {dialog?.kind === 'addText' && (
         <TextDocumentDialog
           t={t}
@@ -1758,10 +1889,10 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
               </ul>
             )}
             <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
-              <button style={style.primary} disabled={pendingResolution !== null} onClick={() => resolveConflict('rename')}>
+              <button className="kb-primary" style={style.primary} disabled={pendingResolution !== null} onClick={() => resolveConflict('rename')}>
                 {pendingResolution === 'rename' ? t('resolvingConflict') : t('conflictKeepAll')}
               </button>
-              <button style={style.primaryDanger} disabled={pendingResolution !== null} onClick={() => resolveConflict('replace')}>
+              <button className="kb-danger-primary" style={style.primaryDanger} disabled={pendingResolution !== null} onClick={() => resolveConflict('replace')}>
                 {pendingResolution === 'replace' ? t('resolvingConflict') : t('conflictReplaceAll')}
               </button>
               <button style={style.button} disabled={pendingResolution !== null} onClick={() => resolveConflict('cancel')}>
@@ -1838,11 +1969,11 @@ function failureReasonLabel(doc: DocumentSummary, t: Translate): string {
     case 'interrupted':
       return t('errorInterrupted')
     case 'dimension_mismatch':
-      return `${t('errorDimensionMismatch')}：${doc.embeddingError ?? ''}`
+      return `${t('errorDimensionMismatch')}: ${doc.embeddingError ?? ''}`
     case 'parse_failed':
-      return `${t('errorParseFailed')}：${doc.embeddingError ?? ''}`
+      return `${t('errorParseFailed')}: ${doc.embeddingError ?? ''}`
     case 'embedding_provider':
-      return `${t('errorEmbeddingProvider')}：${doc.embeddingError ?? ''}`
+      return `${t('errorEmbeddingProvider')}: ${doc.embeddingError ?? ''}`
     default:
       return doc.embeddingError ?? t('embeddingFailed')
   }
@@ -1895,7 +2026,7 @@ function RecallPanel(props: {
             >🕘</button>
           )}
         </div>
-        <button style={style.primary} disabled={!canSearch} onClick={() => props.onSearch(props.searchQuery)}>⚡{t('searchButton')}</button>
+        <button className="kb-primary" style={style.primary} disabled={!canSearch} onClick={() => props.onSearch(props.searchQuery)}>⚡{t('searchButton')}</button>
 
         {hasHistory && historyOpen && (
           <div style={{ position: 'absolute', top: 'calc(100% + 4px)', left: 0, right: 0, zIndex: 40, maxHeight: 220, overflowY: 'auto', background: C.overlay, border: `1px solid ${C.border}`, borderRadius: 10, boxShadow: '0 10px 32px rgba(0,0,0,0.18)', padding: 4 }}>
@@ -1964,7 +2095,7 @@ function RecallResultCard(props: { hit: SearchHit; index: number; t: Translate }
     try {
       // Copy a full Markdown citation (quote + source) so the excerpt can be
       // pasted into the conversation with its traceable source line.
-      await navigator.clipboard.writeText(citationMarkdown(hit))
+      await navigator.clipboard.writeText(citationMarkdown(hit, t))
       setCopied(true)
       window.setTimeout(() => setCopied(false), 2000)
     } catch {
@@ -1998,23 +2129,47 @@ function RecallResultCard(props: { hit: SearchHit; index: number; t: Translate }
   )
 }
 
-function SidePanel(props: { title: string; onClose: () => void; children: React.ReactNode }): JSX.Element {
+function SidePanel(props: {
+  title: string
+  onClose: () => void
+  children: React.ReactNode
+  width?: number
+  onResizeWidth?: (event: React.MouseEvent) => void
+}): JSX.Element {
+  const resizable = props.onResizeWidth !== undefined
   return (
     <div style={style.sidePanelScrim} onClick={props.onClose}>
-      <div style={style.sidePanel} onClick={(e) => e.stopPropagation()}>
-        <div style={style.sidePanelHeader}>
-          <span style={{ fontSize: 14, fontWeight: 600 }}>{props.title}</span>
-          <button className="kb-row" style={style.closeButton} onClick={props.onClose} aria-label="close">✕</button>
+      <div
+        style={{ ...style.sidePanel, width: props.width ?? 460, flexDirection: 'row' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {resizable && (
+          <div
+            className="kb-sash"
+            onMouseDown={props.onResizeWidth}
+            style={{
+              width: 8, cursor: 'col-resize', flexShrink: 0, alignSelf: 'stretch',
+              position: 'relative', zIndex: 6, borderRight: `1px solid ${C.border}`,
+            }}
+            title="Drag to resize"
+            aria-label="Drag to resize"
+          />
+        )}
+        <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+          <div style={style.sidePanelHeader}>
+            <span style={{ fontSize: 14, fontWeight: 600 }}>{props.title}</span>
+            <button className="kb-row" style={style.closeButton} onClick={props.onClose} aria-label="close">✕</button>
+          </div>
+          <div style={style.sidePanelBody} className="kb-scroll">{props.children}</div>
         </div>
-        <div style={style.sidePanelBody} className="kb-scroll">{props.children}</div>
       </div>
     </div>
   )
 }
 
-function StatChip(props: { value: string | number; label: string }): JSX.Element {
+function StatChip(props: { value: string | number; label: string; title?: string }): JSX.Element {
   return (
-    <span style={style.statChip}>
+    <span style={style.statChip} title={props.title}>
       <span style={style.statValue}>{props.value}</span>
       <span style={style.statLabel}>{props.label}</span>
     </span>
@@ -2290,7 +2445,7 @@ function DocumentDetailPanel(props: {
                 return (
                   <div key={chunk.id} style={{ border: `1px solid ${C.border}`, borderRadius: 8, marginBottom: 8, background: C.surface }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px', borderBottom: `1px solid ${C.border}` }}>
-                      <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', minWidth: 20, height: 20, padding: '0 6px', borderRadius: 5, background: C.accent, color: '#fff', fontSize: 11, fontWeight: 600 }}>{chunk.index + 1}</span>
+                      <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', minWidth: 20, height: 20, padding: '0 6px', borderRadius: 5, background: C.accent, color: 'var(--dsw-alias-label-primary-foreground, #fff)', fontSize: 11, fontWeight: 600 }}>{chunk.index + 1}</span>
                       <span style={{ flex: 1, minWidth: 0, fontSize: 11, color: C.muted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {chunk.heading !== undefined ? chunk.heading : ''}
                       </span>
@@ -2338,12 +2493,12 @@ function scoreColor(score: number, palette: typeof C): string {
 }
 
 /** Markdown citation block for one search hit: quote + source line. */
-function citationMarkdown(hit: SearchHit): string {
+function citationMarkdown(hit: SearchHit, t: Translate): string {
   const quote = hit.text.split('\n').map(line => `> ${line}`).join('\n')
   const source = hit.heading !== undefined && hit.heading.length > 0
     ? `${hit.documentTitle} / ${hit.heading}`
     : hit.documentTitle
-  return `${quote}\n>\n> — ${source}（知识库 ${hit.baseId}）`
+  return `${quote}\n>\n> — ${source}${t('citationSource').replace('{id}', hit.baseId)}`
 }
 
 function highlightMatches(text: string, query: string, markStyle: CSSProperties): JSX.Element {

--- a/src/ui/client/LocalModelsSection.tsx
+++ b/src/ui/client/LocalModelsSection.tsx
@@ -125,7 +125,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
   const browseCacheDir = useCallback(async (): Promise<void> => {
     setError(null)
     if (props.workspaces === undefined) {
-      setError('文件夹选择不可用（当前环境无目录选择能力）')
+      setError(t('cacheDirPickUnavailable'))
       return
     }
     try {
@@ -134,7 +134,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     }
-  }, [props.workspaces])
+  }, [props.workspaces, t])
 
   const openCacheDir = useCallback(async (): Promise<void> => {
     setError(null)
@@ -155,7 +155,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
       setCacheDir(result.to)
       setError(null)
       if (result.moved > 0) {
-        setError(`${result.moved} 个模型目录已迁移到 ${result.to}`)
+        setError(t('cacheDirMigrated').replace('{count}', String(result.moved)).replace('{to}', result.to))
       } else {
         // Also silent before: a no-op migration (same dir, or the target
         // already holds the entries) showed nothing at all.
@@ -180,6 +180,24 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
       setOllamaBusy(false)
     }
   }, [api, ollamaBase, t])
+
+  // Make the Ollama server used here the global embedding default, so new
+  // bases inherit it (per-base settings only override it). Non-fatal on
+  // error — model management must keep working even if persistence fails.
+  const persistOllamaDefault = useCallback((): void => {
+    const base = ollamaBase.trim()
+    if (base === '') return
+    void api.setConfig({ embeddingProvider: 'ollama', embeddingBaseUrl: base }).catch(() => {})
+    // Also default the embedding model so a fresh base embeds out of the box:
+    // the first installed embedding model (or a recommended one) becomes the
+    // global default only while none is configured yet.
+    void api.getConfig().then(current => {
+      if ((current.embeddingModel ?? '').trim() !== '') return
+      const candidate = [...ollamaSuggestions.ollamaEmbedding, ...ollamaInstalled.map(m => m.name)]
+        .find(name => /embed|bge|mxbai|e5|gte|nomic/i.test(name))
+      if (candidate !== undefined) void api.setConfig({ embeddingModel: candidate }).catch(() => {})
+    }).catch(() => {})
+  }, [api, ollamaBase, ollamaInstalled, ollamaSuggestions])
 
   // Live Ollama pull progress (polled only while a pull is actually running).
   // The moment a pull leaves the `pulling` state its card clears and, on
@@ -252,6 +270,14 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
     setError(null)
     try {
       await api.pullOllamaModel(model, ollamaBase)
+      // Pulling from an Ollama server makes it the global embedding default
+      // (provider + URL), so new bases inherit it instead of reconfiguring.
+      persistOllamaDefault()
+      // If the pulled model is an embedding model, also set it as the global
+      // embedding-model default.
+      if (ollamaSuggestions.ollamaEmbedding.includes(model) || /embed|bge|mxbai|e5|gte|nomic/i.test(model)) {
+        void api.setConfig({ embeddingModel: model }).catch(() => {})
+      }
       setPullingModels(prev => prev.some(p => p.model === model)
         ? prev
         : [...prev, { model, status: 'pulling', progress: 0, message: '' }])
@@ -264,7 +290,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
       setError(`${err instanceof Error ? err.message : String(err)} ${t('ollamaNeedInstall')}`)
       setOllamaBusy(false)
     }
-  }, [api, ollamaModel, ollamaBase, t])
+  }, [api, ollamaModel, ollamaBase, ollamaSuggestions, persistOllamaDefault, t])
 
   const cancelOllama = useCallback(async (model: string): Promise<void> => {
     try {
@@ -559,7 +585,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
             value={ollamaBase}
             onChange={(e) => setOllamaBase(e.target.value)}
           />
-          <button className="kb-btn" style={style.button} disabled={ollamaBusy} onClick={() => void refreshOllamaTags()}>
+          <button className="kb-btn" style={style.button} disabled={ollamaBusy} onClick={() => { persistOllamaDefault(); void refreshOllamaTags() }}>
             <IconRefresh size={13} />{t('ollamaRefresh')}
           </button>
         </div>

--- a/src/ui/client/api.ts
+++ b/src/ui/client/api.ts
@@ -42,16 +42,29 @@ export interface BaseConfig {
   resumeInterruptedOnStartup?: boolean
 }
 
+/** One origin line for a base: where its content came from (shown under the
+ *  base name in the detail header — path for directories/files, link for URLs,
+ *  "node" for manually added text). */
+export interface BaseSourceInfo {
+  kind: 'text' | 'file' | 'url' | 'directory'
+  /** Directory path / file name / URL / 'node'. */
+  text: string
+}
+
 export interface BaseSummary {
   id: string
   name: string
   description: string
   group?: string
   documentCount: number
+  /** Documents with a persisted raw source copy (actually imported & stored). */
+  storedDocCount: number
   chunkCount: number
   charCount: number
   tokenCount: number
   config?: BaseConfig
+  /** Top-level sources of the base's content, for display (bounded). */
+  sourceInfo?: BaseSourceInfo[]
   createdAt: number
   updatedAt: number
 }
@@ -232,6 +245,8 @@ export interface RerankStatus {
 export interface BaseStats {
   baseId?: string
   documentCount: number
+  /** Documents with a persisted raw source copy (actually imported & stored). */
+  storedDocCount: number
   chunkCount: number
   charCount: number
   tokenCount: number
@@ -275,14 +290,16 @@ interface Envelope<T> {
 }
 
 export class KnowledgeApi {
-  private async call<T>(method: string, path: string, body?: unknown): Promise<T> {
+  private async call<T>(method: string, path: string, body?: unknown, timeoutMs = 60_000): Promise<T> {
     const response = await fetch(`/knowledge${path}`, {
       method,
       headers: body !== undefined ? { 'content-type': 'application/json' } : undefined,
       body: body !== undefined ? JSON.stringify(body) : undefined,
       // A hung host must not pin the panel's busy state forever: fail the
-      // call with a clear error instead of an indefinite spinner.
-      signal: AbortSignal.timeout(60_000),
+      // call with a clear error instead of an indefinite spinner. Long-running
+      // jobs (reindex of a whole base) pass a larger budget so a slow sweep is
+      // not cut short while the server is still working.
+      signal: AbortSignal.timeout(timeoutMs),
     })
     let envelope: Envelope<T>
     try {
@@ -517,6 +534,16 @@ export class KnowledgeApi {
     return this.call('POST', `/bases/${encodeURIComponent(baseId)}/import-directory-tree`, { baseId, path })
   }
 
+  /** Import a local directory or single file by its absolute path (validated server-side). */
+  importFromPath(baseId: string, path: string): Promise<{ kind: 'directory' | 'file'; imported: number }> {
+    return this.call('POST', `/bases/${encodeURIComponent(baseId)}/import-path`, { baseId, path })
+  }
+
+  /** Repoint the base's source path (validated server-side). */
+  setBaseSourcePath(baseId: string, path: string): Promise<{ set: number }> {
+    return this.call('POST', `/bases/${encodeURIComponent(baseId)}/source-path`, { baseId, path })
+  }
+
   getDirectoryImport(jobId: string): Promise<DirectoryImportStatus> {
     return this.call('GET', `/import-directory/${encodeURIComponent(jobId)}`)
   }
@@ -541,7 +568,7 @@ export class KnowledgeApi {
   }
 
   reindexDocument(documentId: string): Promise<{ id: string; chunkCount: number }> {
-    return this.call('POST', `/documents/${encodeURIComponent(documentId)}/reindex`)
+    return this.call('POST', `/documents/${encodeURIComponent(documentId)}/reindex`, undefined, 30 * 60_000)
   }
 
   refreshUrlDocument(documentId: string): Promise<{ changed: boolean; title: string; chunkCount: number }> {
@@ -549,7 +576,7 @@ export class KnowledgeApi {
   }
 
   reindexDocuments(ids: string[]): Promise<{ reindexed: number; skipped: number }> {
-    return this.call('POST', '/documents/reindex', { ids })
+    return this.call('POST', '/documents/reindex', { ids }, 30 * 60_000)
   }
 
   deleteDocument(id: string): Promise<{ deleted: boolean }> {

--- a/src/ui/client/dialogs.tsx
+++ b/src/ui/client/dialogs.tsx
@@ -20,7 +20,7 @@ export interface Toast {
   text: string
 }
 
-export function Toasts(props: { toasts: readonly Toast[] }): JSX.Element | null {
+export function Toasts(props: { toasts: readonly Toast[]; onDismiss?: (id: number) => void }): JSX.Element | null {
   if (props.toasts.length === 0) return null
   return (
     <div style={style.toastStack}>
@@ -33,7 +33,10 @@ export function Toasts(props: { toasts: readonly Toast[] }): JSX.Element | null 
               : toast.kind === 'warning'
                 ? <IconX size={14} color="#f5a524" />
                 : null}
-          <span>{toast.text}</span>
+          <span style={{ userSelect: 'text', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{toast.text}</span>
+          <button style={style.toastClose} onClick={() => props.onDismiss?.(toast.id)} aria-label="close">
+            <IconX size={12} color={C.muted} />
+          </button>
         </div>
       ))}
     </div>
@@ -77,7 +80,7 @@ export function ConfirmDialog(props: {
       <p style={{ fontSize: 13, margin: '0 0 16px', lineHeight: 1.6 }}>{props.message}</p>
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>✕</button>
-        <button style={style.primaryDanger} onClick={props.onConfirm} disabled={props.busy === true}>{props.confirmLabel}</button>
+        <button className="kb-danger-primary" style={style.primaryDanger} onClick={props.onConfirm} disabled={props.busy === true}>{props.confirmLabel}</button>
       </div>
     </Modal>
   )
@@ -116,7 +119,7 @@ export function PromptDialog(props: {
       </div>
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>✕</button>
-        <button style={style.primary} disabled={submitting || value.trim().length === 0} onClick={submit}>OK</button>
+        <button className="kb-primary" style={style.primary} disabled={submitting || value.trim().length === 0} onClick={submit}>OK</button>
       </div>
     </Modal>
   )
@@ -157,7 +160,7 @@ export function TextDocumentDialog(props: {
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>{props.t('cancel')}</button>
         <button
-          style={style.primary}
+          className="kb-primary" style={style.primary}
           disabled={props.busy === true || title.trim().length === 0 || content.trim().length === 0}
           onClick={() => props.onCreate(title.trim(), content)}
         >
@@ -200,11 +203,17 @@ export function RestoreBaseDialog(props: {
       </div>
       <div style={style.field}>
         <label style={style.label}>{props.t('embeddingModel')}</label>
-        <select style={style.input} value={provider} onChange={(e) => setProvider(e.target.value as typeof provider)}>
+        <select style={style.input} value={provider} onChange={(e) => {
+          const next = e.target.value as typeof provider
+          // Auto-fill the well-known local Ollama endpoint when the user
+          // switches to Ollama, so the URL is not retyped by hand.
+          if (next === 'ollama' && baseUrl.trim() === '') setBaseUrl('http://127.0.0.1:11434')
+          setProvider(next)
+        }}>
           <option value="none">{props.t('restoreKeepModel')}</option>
-          <option value="openai">OpenAI 兼容</option>
+          <option value="openai">{props.t('providerOpenAI')}</option>
           <option value="ollama">Ollama</option>
-          <option value="local">本地模型</option>
+          <option value="local">{props.t('providerLocal')}</option>
         </select>
       </div>
       {modelChanged && (
@@ -257,7 +266,7 @@ export function RestoreBaseDialog(props: {
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>{props.t('cancel')}</button>
         <button
-          style={style.primary}
+          className="kb-primary" style={style.primary}
           disabled={props.busy === true || name.trim().length === 0 || (modelChanged && model.trim().length === 0)}
           onClick={() => props.onRestore(
             name.trim(),
@@ -308,7 +317,7 @@ export function CreateBaseDialog(props: {
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>{props.t('cancel')}</button>
         <button
-          style={style.primary}
+          className="kb-primary" style={style.primary}
           disabled={props.busy === true || name.trim().length === 0}
           onClick={() => props.onCreate(name.trim(), description.trim(), group.trim() === '' ? undefined : group.trim())}
         >

--- a/src/ui/client/locales.ts
+++ b/src/ui/client/locales.ts
@@ -111,6 +111,10 @@ export type KnowledgeKey =
   | 'batchSize'
   | 'stats'
   | 'statsDocs'
+  | 'statsSourceDocs'
+  | 'statsStoredDocs'
+  | 'statsSourceDocsTitle'
+  | 'statsStoredDocsTitle'
   | 'statsChunks'
   | 'statsChars'
   | 'statsTokens'
@@ -125,6 +129,10 @@ export type KnowledgeKey =
   | 'docCount'
   | 'chunkCount'
   | 'tabDir'
+  | 'tabPath'
+  | 'pathDesc'
+  | 'sourcePathEdit'
+  | 'sourcePathPrompt'
   | 'dirPlaceholder'
   | 'importDirButton'
   | 'conflictTitle'
@@ -299,6 +307,18 @@ export type KnowledgeKey =
   | 'kbScopeHint'
   | 'dragResize'
   | 'loadMoreChunks'
+  | 'timeJustNow'
+  | 'timeMinutes'
+  | 'timeHours'
+  | 'timeDays'
+  | 'cacheDirPickUnavailable'
+  | 'cacheDirMigrated'
+  | 'mineruOption'
+  | 'mineruHostPlaceholder'
+  | 'visionModelPlaceholder'
+  | 'captionBaseUrlOllamaPlaceholder'
+  | 'captionBaseUrlPlaceholder'
+  | 'citationSource'
   | 'error'
 
 /** Bound translate over the knowledge dictionary. */
@@ -402,6 +422,10 @@ export const zh: Record<KnowledgeKey, string> = {
   batchSize: 'embedding 批大小',
   stats: '统计',
   statsDocs: '文档',
+  statsSourceDocs: '来源文档',
+  statsStoredDocs: '已解析文档',
+  statsSourceDocsTitle: '来源中跟踪的项目（文件夹 + 文件）',
+  statsStoredDocsTitle: '实际解析并作为原始副本存储在缓存中的文档',
   statsChunks: '分块',
   statsChars: '字符',
   statsTokens: '≈ Token',
@@ -416,6 +440,10 @@ export const zh: Record<KnowledgeKey, string> = {
   docCount: '个文档',
   chunkCount: '个分块',
   tabDir: '目录',
+  tabPath: '路径',
+  pathDesc: '输入目录或文件的绝对路径',
+  sourcePathEdit: '修改来源路径',
+  sourcePathPrompt: '来源路径',
   dirPlaceholder: '输入本机目录路径，如 D:\\docs\\policy',
   importDirButton: '导入',
   conflictTitle: '存在同名数据源',
@@ -599,6 +627,18 @@ export const zh: Record<KnowledgeKey, string> = {
   kbScopeHint: '留空 = 全部库可用',
   dragResize: '拖动调整宽度',
   loadMoreChunks: '加载更多分块',
+  timeJustNow: '刚刚',
+  timeMinutes: '{n} 分钟前',
+  timeHours: '{n} 小时前',
+  timeDays: '{n} 天前',
+  cacheDirPickUnavailable: '文件夹选择不可用（当前环境无目录选择能力）',
+  cacheDirMigrated: '{count} 个模型目录已迁移到 {to}',
+  mineruOption: 'MinerU（远程，扫描件/复杂版面）',
+  mineruHostPlaceholder: 'API Host（默认 https://mineru.net）',
+  visionModelPlaceholder: '视觉模型（如 qwen-vl-plus、gpt-4o-mini）',
+  captionBaseUrlOllamaPlaceholder: 'Ollama 地址（默认 http://127.0.0.1:11434）',
+  captionBaseUrlPlaceholder: 'API 地址（留空用嵌入模型地址）',
+  citationSource: '（知识库 {id}）',
   error: '出错了',
 }
 
@@ -700,6 +740,10 @@ export const en: Record<KnowledgeKey, string> = {
   batchSize: 'Embedding batch size',
   stats: 'Stats',
   statsDocs: 'docs',
+  statsSourceDocs: 'source docs',
+  statsStoredDocs: 'parsed docs',
+  statsSourceDocsTitle: 'Items tracked from the source (folders + files)',
+  statsStoredDocsTitle: 'Documents actually parsed and stored as raw copies in the cache',
   statsChunks: 'chunks',
   statsChars: 'chars',
   statsTokens: '~tokens',
@@ -714,6 +758,10 @@ export const en: Record<KnowledgeKey, string> = {
   docCount: ' docs',
   chunkCount: ' chunks',
   tabDir: 'Directory',
+  tabPath: 'Path',
+  pathDesc: 'Absolute path to a directory or file',
+  sourcePathEdit: 'Edit source path',
+  sourcePathPrompt: 'Source path',
   dirPlaceholder: 'Enter a local directory path, e.g. D:\\docs\\policy',
   importDirButton: 'Import',
   conflictTitle: 'Same-name source',
@@ -792,7 +840,7 @@ export const en: Record<KnowledgeKey, string> = {
   noOllamaModels: 'No installed Ollama models — pull one in Settings → Local Models',
   selectModelPlaceholder: 'Select a model',
   ollamaUnreachable: 'Cannot reach Ollama (check the address or whether it is running)',
-  embeddingSwitchWarning: '⚠ Switching the embedding model invalidates this base\'s stored vectors, so the save will be refused — rebuild via 重建知识库 with the new model instead (or empty the base first)',
+  embeddingSwitchWarning: '⚠ Switching the embedding model invalidates this base\'s stored vectors, so the save will be refused — rebuild via \u201cRebuild base\u201d with the new model instead (or empty the base first)',
   staleModelSuffix: ' (not installed)',
   embeddingModelMissingHint: 'The embedding provider is the local model, which is not downloaded yet — imported content cannot be vectorized for retrieval. Download the embedding model (~585MB) in Settings → Local Models first.',
   localModelStatusLabel: 'Local embedding model',
@@ -897,5 +945,17 @@ export const en: Record<KnowledgeKey, string> = {
   kbScopeHint: 'Empty = all bases',
   dragResize: 'Drag to resize',
   loadMoreChunks: 'Load more chunks',
+  timeJustNow: 'just now',
+  timeMinutes: '{n} min ago',
+  timeHours: '{n} h ago',
+  timeDays: '{n} d ago',
+  cacheDirPickUnavailable: 'Folder picking is unavailable (this environment has no directory picker)',
+  cacheDirMigrated: '{count} model director(y/ies) moved to {to}',
+  mineruOption: 'MinerU (remote, scans/complex layouts)',
+  mineruHostPlaceholder: 'API Host (default https://mineru.net)',
+  visionModelPlaceholder: 'Vision model (e.g. qwen-vl-plus, gpt-4o-mini)',
+  captionBaseUrlOllamaPlaceholder: 'Ollama URL (default http://127.0.0.1:11434)',
+  captionBaseUrlPlaceholder: 'API URL (leave empty to use the embedding model URL)',
+  citationSource: ' (KB {id})',
   error: 'Error',
 }

--- a/src/ui/client/popover.tsx
+++ b/src/ui/client/popover.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type { ReactNode } from 'react'
 import { style } from './theme.js'
 
@@ -26,38 +27,107 @@ export function PopoverMenu(props: {
 }): JSX.Element {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
+  // The menu renders in a body-level portal, OUTSIDE ref — track it too so
+  // clicks on menu items are not treated as outside-clicks (otherwise the
+  // mousedown dismissal unmounts the menu before the item's click fires and
+  // every menu action silently dies).
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [pos, setPos] = useState<{ top: number; left?: number; right?: number } | null>(null)
 
   useEffect(() => {
     if (!open) return
     const onDocumentClick = (event: MouseEvent): void => {
-      if (ref.current !== null && !ref.current.contains(event.target as Node)) setOpen(false)
+      const target = event.target as Node
+      if (ref.current !== null && ref.current.contains(target)) return
+      if (menuRef.current !== null && menuRef.current.contains(target)) return
+      setOpen(false)
     }
+    const onScroll = (): void => setOpen(false)
+    const onResize = (): void => setOpen(false)
     document.addEventListener('mousedown', onDocumentClick)
-    return () => document.removeEventListener('mousedown', onDocumentClick)
+    window.addEventListener('scroll', onScroll, true)
+    window.addEventListener('resize', onResize)
+    return () => {
+      document.removeEventListener('mousedown', onDocumentClick)
+      window.removeEventListener('scroll', onScroll, true)
+      window.removeEventListener('resize', onResize)
+    }
   }, [open])
+
+  const toggle = (): void => {
+    const next = !open
+    setOpen(next)
+    if (next && ref.current !== null) {
+      const rect = ref.current.getBoundingClientRect()
+      // Open below the trigger; flip above when there isn't enough room below
+      // (menu is rendered in a body-level portal so it must stay in the viewport).
+      const est = estimateMenuHeight(props.entries)
+      const below = window.innerHeight - rect.bottom - 8
+      const above = rect.top - 8
+      const top = (below >= est || below >= above) ? rect.bottom + 4 : Math.max(8, rect.top - est - 4)
+      setPos({
+        top,
+        left: props.align === 'end' ? undefined : rect.left,
+        right: props.align === 'end' ? window.innerWidth - rect.right : undefined,
+      })
+    }
+  }
 
   return (
     <div ref={ref} style={{ position: 'relative', display: 'inline-flex' }}>
       <span
         style={{ display: 'inline-flex' }}
-        onClick={(e) => { e.stopPropagation(); setOpen(v => !v) }}
+        onClick={(e) => { e.stopPropagation(); toggle() }}
       >
         {props.trigger}
       </span>
-      {open && (
+      {open && pos !== null && createPortal(
         <div
-          style={{ ...style.menu, top: 'calc(100% + 4px)', ...(props.align === 'end' ? { right: 0 } : { left: 0 }) }}
+          ref={menuRef}
+          style={{
+            ...style.menu,
+            position: 'fixed',
+            top: pos.top,
+            left: pos.left,
+            right: pos.right,
+            // Body-level portal: sit above the whole panel (zIndex 300) so the
+            // menu can never be buried by list rows or clipped by a scrollable
+            // sidebar's overflow.
+            zIndex: 1000,
+          }}
           onClick={(e) => e.stopPropagation()}
         >
           <MenuItems entries={props.entries} onCloseAll={() => setOpen(false)} />
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   )
 }
 
+/** Rough menu height for deciding whether to open below vs above the trigger. */
+function estimateMenuHeight(entries: readonly MenuEntry[]): number {
+  let h = 8 // menu vertical padding
+  for (const e of entries) h += e.label === undefined ? 9 : 36 // separator vs item
+  return h
+}
+
 function MenuItems(props: { entries: readonly MenuEntry[]; onCloseAll: () => void }): JSX.Element {
   const [openSub, setOpenSub] = useState<string | null>(null)
+  const closeTimer = useRef<number | null>(null)
+  const cancelClose = (): void => {
+    if (closeTimer.current !== null) {
+      window.clearTimeout(closeTimer.current)
+      closeTimer.current = null
+    }
+  }
+  const scheduleClose = (): void => {
+    cancelClose()
+    closeTimer.current = window.setTimeout(() => setOpenSub(null), 150)
+  }
+  useEffect(() => () => {
+    if (closeTimer.current !== null) window.clearTimeout(closeTimer.current)
+  }, [])
   return (
     <>
       {props.entries.map(entry =>
@@ -65,11 +135,11 @@ function MenuItems(props: { entries: readonly MenuEntry[]; onCloseAll: () => voi
           ? <div key={entry.key} style={style.menuSeparator} />
           : (
               <div key={entry.key} style={{ position: 'relative' }}
-                onMouseEnter={() => entry.children !== undefined && setOpenSub(entry.key)}
-                onMouseLeave={() => { if (openSub === entry.key) setOpenSub(null) }}
+                onMouseEnter={() => { if (entry.children !== undefined) { cancelClose(); setOpenSub(entry.key) } }}
+                onMouseLeave={() => { if (openSub === entry.key) scheduleClose() }}
               >
                 <button
-                  className="kb-row"
+                  className="kb-row kb-menuitem"
                   style={{ ...style.menuItem, ...(entry.danger === true ? style.menuItemDanger : {}) }}
                   onClick={() => {
                     if (entry.children !== undefined) {
@@ -87,10 +157,13 @@ function MenuItems(props: { entries: readonly MenuEntry[]; onCloseAll: () => voi
                   {entry.children !== undefined && <span style={{ color: 'inherit', opacity: 0.55, fontSize: 10 }}>▸</span>}
                 </button>
                 {entry.children !== undefined && openSub === entry.key && (
-                  <div style={{ ...style.menu, top: -4, left: 'calc(100% + 4px)', position: 'absolute' }}>
+                  <div style={{ ...style.menu, top: 'calc(100% + 4px)', left: 0, position: 'absolute' }}
+                    onMouseEnter={cancelClose}
+                    onMouseLeave={scheduleClose}
+                  >
                     <MenuItems
                       entries={entry.children}
-                      onCloseAll={() => { setOpenSub(null); props.onCloseAll() }}
+                      onCloseAll={() => { cancelClose(); setOpenSub(null); props.onCloseAll() }}
                     />
                   </div>
                 )}

--- a/src/ui/client/rag-config.tsx
+++ b/src/ui/client/rag-config.tsx
@@ -185,7 +185,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
         }
       } catch (err) {
         setProbing(false)
-        setSaveError(`${t('dimensionProbeFailed')}：${err instanceof Error ? err.message : String(err)}`)
+        setSaveError(`${t('dimensionProbeFailed')}: ${err instanceof Error ? err.message : String(err)}`)
         return
       }
       setProbing(false)
@@ -223,7 +223,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
             onChange={(e) => patch({ documentProcessorProvider: e.target.value as 'builtin' | 'mineru' })}
           >
             <option value="builtin">{t('processorBuiltin')}</option>
-            <option value="mineru">MinerU（远程，扫描件/复杂版面）</option>
+            <option value="mineru">{t('mineruOption')}</option>
           </select>
           {values.documentProcessorProvider === 'mineru' && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
@@ -236,7 +236,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
               />
               <input
                 style={style.input}
-                placeholder="API Host（默认 https://mineru.net）"
+                placeholder={t('mineruHostPlaceholder')}
                 value={values.mineruApiHost}
                 onChange={(e) => patch({ mineruApiHost: e.target.value })}
               />
@@ -292,7 +292,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
                 ) : (
                   <input
                     style={style.input}
-                    placeholder="视觉模型（如 qwen-vl-plus、gpt-4o-mini）"
+                    placeholder={t('visionModelPlaceholder')}
                     value={values.imageCaptionModel}
                     onChange={(e) => patch({ imageCaptionModel: e.target.value })}
                   />
@@ -300,8 +300,8 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
                 <input
                   style={style.input}
                   placeholder={values.imageCaptionProvider === 'ollama'
-                    ? 'Ollama 地址（默认 http://127.0.0.1:11434）'
-                    : 'API 地址（留空用嵌入模型地址）'}
+                    ? t('captionBaseUrlOllamaPlaceholder')
+                    : t('captionBaseUrlPlaceholder')}
                   value={values.imageCaptionBaseUrl}
                   onChange={(e) => patch({ imageCaptionBaseUrl: e.target.value })}
                 />
@@ -343,7 +343,13 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
                 const next = ollamaEmbeddingModels.includes(values.embeddingModel)
                   ? values.embeddingModel
                   : (ollamaEmbeddingModels[0] ?? '')
-                patch({ embeddingProvider: provider, embeddingModel: next })
+                // Auto-fill the well-known local Ollama endpoint so a user
+                // creating a fresh base does not retype http://127.0.0.1:11434
+                // every time (the model name is already auto-picked).
+                const nextBase = values.embeddingBaseUrl.trim() === ''
+                  ? 'http://127.0.0.1:11434'
+                  : values.embeddingBaseUrl
+                patch({ embeddingProvider: provider, embeddingModel: next, embeddingBaseUrl: nextBase })
               } else {
                 // openai / none: free-text or none — keep whatever was typed.
                 patch({ embeddingProvider: provider })
@@ -683,7 +689,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
         >
           <IconRefresh size={13} />{t('reset')}
         </button>
-        <button style={style.primary} disabled={!dirty || busy || probing} onClick={() => void save()}>
+        <button className="kb-primary" style={style.primary} disabled={!dirty || busy || probing} onClick={() => void save()}>
           {probing ? t('dimensionProbing') : t('save')}
         </button>
       </div>

--- a/src/ui/client/react-dom.d.ts
+++ b/src/ui/client/react-dom.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Ambient declaration for the external `react-dom` module.
+ * `react-dom` is NOT installed here — the DSH shell injects it into the
+ * frozen client module table at runtime (see build.mjs clientExternal), so
+ * esbuild keeps it external. This declaration gives tsc the one member we
+ * use without pulling in @types/react-dom.
+ */
+declare module 'react-dom' {
+  import type { ReactNode } from 'react'
+  export function createPortal(children: ReactNode, container: Element | DocumentFragment): ReactNode
+}

--- a/src/ui/client/theme.ts
+++ b/src/ui/client/theme.ts
@@ -11,10 +11,17 @@ export const C = {
   surface: 'var(--dsw-alias-bg-layer-1, #ffffff)',
   surface2: 'var(--dsw-alias-bg-layer-2, #f1f2f5)',
   overlay: 'var(--dsw-alias-bg-overlay, #ffffff)',
-  border: 'var(--dsw-alias-border-l1, #e3e5e9)',
-  borderStrong: 'var(--dsw-alias-border-l2, #c7ccd4)',
   text: 'var(--dsw-alias-label-primary, #1f2329)',
-  muted: 'var(--dsw-alias-label-secondary, #8a919c)',
+  // DSH's label-secondary is extremely faint in the light theme (#cfd3d6 on
+  // white ≈ 1.4:1), which makes hint/secondary text visually merge with the
+  // surface. Derive a readable "muted" from the primary label color instead
+  // (≈72% of near-black in light, ≈72% of near-white in dark), so it stays
+  // legible in both DSH themes while still reading as secondary.
+  muted: 'color-mix(in srgb, var(--dsw-alias-label-primary, #1f2329) 72%, transparent)',
+  // DSH's border-l1 is ~6% black / 9% white — too faint to separate panels.
+  // Use the stronger border-l2 / border-l3 tiers for card and control edges.
+  border: 'var(--dsw-alias-border-l2, #c7ccd4)',
+  borderStrong: 'var(--dsw-alias-border-l3, #9aa1ab)',
   accent: 'var(--dsw-alias-brand-primary, #3b6ef6)',
   danger: 'var(--dsw-alias-state-error-primary, #e5484d)',
   success: 'var(--dsw-alias-state-success-primary, #30a46c)',
@@ -29,8 +36,24 @@ export const PANEL_CSS = `
 @keyframes kb-fade-in { from { opacity: 0; transform: translateY(6px) } to { opacity: 1; transform: none } }
 .kb-spinner { animation: kb-spin 0.9s linear infinite }
 .kb-panel-in { animation: kb-fade-in 0.18s ease-out }
+/* Theme-adaptive interaction fills. DSH's own layer tokens are pure white in
+   the light theme and its interactive-bg-hover is only ~6% alpha, so hovers
+   built on them are nearly invisible. Derive hover/active fills from the
+   inverted label-primary token instead: ~9% black-on-white in light, ~9%
+   white-on-dark in dark — clearly visible in both base themes. Declared on
+   body (portal menus and the sidebar action render outside the panel) and
+   re-scoped to the panel root. */
+body, .kb-panel-in {
+  --kb-hover: color-mix(in srgb, var(--dsw-alias-label-primary, #1f2329) 9%, transparent);
+  --kb-active: color-mix(in srgb, var(--dsw-alias-label-primary, #1f2329) 16%, transparent);
+}
 .kb-row { transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease }
-.kb-row:hover { background: var(--dsw-alias-bg-layer-2, #f1f2f5) }
+.kb-row:hover { background: var(--kb-hover) }
+/* Menu items fill on hover/active; the fill rides a CSS variable referenced from
+   the inline background so the class can override the inline style. */
+.kb-menuitem { transition: background 0.15s ease }
+.kb-menuitem:hover { --kb-mibg: var(--kb-hover) }
+.kb-menuitem:active { --kb-mibg: var(--kb-active) }
 .kb-card { transition: border-color 0.15s ease, background 0.15s ease }
 .kb-card:hover { border-color: var(--dsw-alias-border-l2, #c7ccd4) }
 .kb-iconbtn { transition: color 0.15s ease, background 0.15s ease }
@@ -38,15 +61,43 @@ export const PANEL_CSS = `
 /* Buttons styled with style.button get a hover tint like the shell's own
    buttons. The tint rides a CSS variable referenced from the inline
    background, because inline styles outrank plain class rules: on hover the
-   variable flips and the inline background follows it. */
+   variable flips and the inline background follows it. The .kb-panel-in rule
+   covers every panel button even without the kb-btn class (the class is only
+   required for the settings section, which lives outside the panel). */
 .kb-btn { transition: background 0.15s ease, border-color 0.15s ease }
-.kb-btn:hover { --kb-btn-bg: var(--dsw-alias-interactive-bg-hover, #eceef1) }
+.kb-btn:hover { --kb-btn-bg: var(--kb-hover) }
 .kb-btn:disabled:hover { --kb-btn-bg: var(--dsw-alias-bg-layer-1, #ffffff) }
+.kb-panel-in button:hover { --kb-btn-bg: var(--kb-hover) }
+.kb-panel-in button:disabled:hover { --kb-btn-bg: var(--dsw-alias-bg-layer-1, #ffffff) }
 /* Backgrounds live in classes (not inline) so :hover can override them, the
    same way the shell's Settings trigger styles itself. */
 .kb-sidebar-action { background: transparent }
-.kb-sidebar-action:hover { background: var(--dsw-alias-interactive-bg-hover) }
+.kb-sidebar-action:hover { background: var(--kb-hover) }
+.kb-sidebar-action:active { background: var(--kb-active) }
 .kb-dangerbtn:hover { color: var(--dsw-alias-state-error-primary, #e5484d); background: color-mix(in srgb, var(--dsw-alias-state-error-primary, #e5484d) 10%, transparent) }
+/* Primary (accent-filled) buttons: DSH's brand-primary inverts between themes
+   (near-black in light, near-white in dark) and ships a dedicated hover token,
+   so the hover fill follows that token and stays visible in both. */
+.kb-primary { transition: background 0.15s ease, filter 0.15s ease }
+.kb-primary:hover:not(:disabled) { --kb-primary-bg: var(--dsw-alias-button-primary-hover, #43454a) }
+.kb-primary:active:not(:disabled) { filter: brightness(0.94) }
+.kb-primary:disabled { opacity: 0.5; cursor: not-allowed }
+.kb-danger-primary { transition: background 0.15s ease, filter 0.15s ease }
+.kb-danger-primary:hover:not(:disabled) { --kb-danger-bg: color-mix(in srgb, var(--dsw-alias-state-error-primary, #e5484d) 78%, #000) }
+.kb-danger-primary:active:not(:disabled) { filter: brightness(0.94) }
+.kb-danger-primary:disabled { opacity: 0.5; cursor: not-allowed }
+/* Disabled feedback for every panel button. */
+.kb-panel-in button:disabled { opacity: 0.5; cursor: not-allowed }
+/* Visible focus indicators (DSH's business-primary is a blue that reads in
+   both themes, unlike the inverted brand-primary). */
+.kb-panel-in button:focus-visible, .kb-menuitem:focus-visible, .kb-sidebar-action:focus-visible { outline: 2px solid var(--dsw-alias-state-business-primary, #4176e6); outline-offset: 2px }
+.kb-panel-in input:focus, .kb-panel-in select:focus, .kb-panel-in textarea:focus { box-shadow: 0 0 0 2px color-mix(in srgb, var(--dsw-alias-state-business-primary, #4176e6) 35%, transparent) }
+/* Resize sash: an 8px grab strip whose 2px grip lights up on hover so the
+   draggable edge is discoverable (a 5px transparent sliver was impossible to
+   find/click). z-index keeps it above adjacent scrollbars. */
+.kb-sash { position: relative; z-index: 6 }
+.kb-sash::before { content: ''; position: absolute; top: 0; bottom: 0; left: 50%; transform: translateX(-50%); width: 2px; background: transparent; transition: background 0.15s ease }
+.kb-sash:hover::before { background: color-mix(in srgb, var(--dsw-alias-brand-primary, #3b6ef6) 45%, transparent) }
 .kb-scroll::-webkit-scrollbar { width: 8px; height: 8px }
 .kb-scroll::-webkit-scrollbar-thumb { background: var(--dsw-alias-border-l2, #c7ccd4); border-radius: 999px }
 .kb-scroll::-webkit-scrollbar-track { background: transparent }
@@ -95,6 +146,21 @@ export const style = {
   } as CSSProperties,
   baseName: { fontSize: 13, fontWeight: 600 } as CSSProperties,
   baseMeta: { fontSize: 11, color: C.muted, marginTop: 2 } as CSSProperties,
+  baseSourceRow: {
+    display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '4px 14px',
+    marginTop: 6, padding: '5px 10px', borderRadius: 8,
+    background: 'color-mix(in srgb, var(--dsw-alias-label-primary, #1f2329) 6%, transparent)',
+    fontSize: 11, color: C.muted,
+  } as CSSProperties,
+  baseSourceItem: { display: 'inline-flex', alignItems: 'center', gap: 5, minWidth: 0 } as CSSProperties,
+  baseSourceGlyph: {
+    display: 'inline-flex', alignItems: 'center', flexShrink: 0, color: C.accent,
+  } as CSSProperties,
+  baseSourceText: {
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    fontFamily: "'JetBrains Mono', ui-monospace, 'SF Mono', Consolas, monospace",
+  } as CSSProperties,
+  baseSourceEdit: { marginLeft: 'auto', flexShrink: 0 } as CSSProperties,
   main: { flex: 1, minWidth: 0, overflowY: 'auto', padding: 18, display: 'flex', flexDirection: 'column', gap: 14 } as CSSProperties,
   card: { border: `1px solid ${C.border}`, borderRadius: 12, background: C.surface, padding: 14, position: 'relative' } as CSSProperties,
   cardTitle: { fontSize: 13, fontWeight: 600, margin: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between' } as CSSProperties,
@@ -104,12 +170,16 @@ export const style = {
   } as CSSProperties,
   primary: {
     display: 'inline-flex', alignItems: 'center', gap: 5, border: '1px solid transparent',
-    borderRadius: 8, padding: '6px 14px', background: C.accent, color: '#fff', cursor: 'pointer',
+    borderRadius: 8, padding: '6px 14px', background: `var(--kb-primary-bg, ${C.accent})`,
+    // DSH's brand-primary is near-BLACK in light but near-WHITE in dark; the
+    // foreground token inverts with the theme so the label stays readable on
+    // the accent fill in both modes (white text on white would vanish in dark).
+    color: 'var(--dsw-alias-label-primary-foreground, #fff)', cursor: 'pointer',
     fontSize: 13, fontWeight: 600,
   } as CSSProperties,
   primaryDanger: {
     display: 'inline-flex', alignItems: 'center', gap: 5, border: '1px solid transparent',
-    borderRadius: 8, padding: '6px 14px', background: C.danger, color: '#fff', cursor: 'pointer',
+    borderRadius: 8, padding: '6px 14px', background: `var(--kb-danger-bg, ${C.danger})`, color: 'var(--dsw-alias-label-primary-foreground, #fff)', cursor: 'pointer',
     fontSize: 13, fontWeight: 600,
   } as CSSProperties,
   danger: {
@@ -165,7 +235,8 @@ export const style = {
   empty: { color: C.muted, fontSize: 13, padding: 24, textAlign: 'center' } as CSSProperties,
   error: { color: C.danger, fontSize: 12, background: 'color-mix(in srgb, var(--dsw-alias-state-error-primary, #e5484d) 8%, transparent)', borderRadius: 8, padding: '8px 12px' } as CSSProperties,
   modalBackdrop: {
-    position: 'absolute', inset: 0, zIndex: 20, background: 'rgba(0,0,0,0.32)',
+    position: 'absolute', inset: 0, zIndex: 20, // Less transparent so dialog content stays clearly behind the modal.
+    background: 'rgba(0,0,0,0.58)',
     display: 'flex', alignItems: 'center', justifyContent: 'center',
   } as CSSProperties,
   modal: {
@@ -203,9 +274,14 @@ export const style = {
     display: 'flex', flexDirection: 'column', gap: 8, alignItems: 'center',
   } as CSSProperties,
   toast: {
-    display: 'flex', alignItems: 'center', gap: 8, borderRadius: 999, padding: '8px 16px',
+    display: 'flex', alignItems: 'center', gap: 8, borderRadius: 12, padding: '8px 14px',
     fontSize: 13, fontWeight: 600, background: C.overlay, border: `1px solid ${C.border}`,
-    boxShadow: '0 8px 24px rgba(0,0,0,0.14)', color: C.text,
+    boxShadow: '0 8px 24px rgba(0,0,0,0.14)', color: C.text, maxWidth: 'min(90vw, 560px)',
+  } as CSSProperties,
+  toastClose: {
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+    width: 20, height: 20, border: 'none', borderRadius: 999, background: 'transparent',
+    color: C.muted, cursor: 'pointer', padding: 0, marginLeft: 2,
   } as CSSProperties,
   fileRow: {
     display: 'flex', alignItems: 'center', gap: 8, border: `1px solid ${C.border}`,
@@ -214,10 +290,13 @@ export const style = {
   spinner: { display: 'inline-block', width: 14, height: 14, borderRadius: '50%', border: '2px solid currentColor', borderTopColor: 'transparent' } as CSSProperties,
   menu: {
     position: 'absolute', zIndex: 30, minWidth: 180, borderRadius: 10, padding: 4,
-    background: C.overlay, border: `1px solid ${C.border}`, boxShadow: '0 10px 32px rgba(0,0,0,0.18)',
+    // Opaque overlay surface (never translucent) with the stronger border tier
+    // so the popover separates from the panel in both themes.
+    background: C.overlay, border: `1px solid ${C.borderStrong}`, boxShadow: '0 10px 32px rgba(0,0,0,0.22)',
+    color: C.text,
   } as CSSProperties,
   menuItem: {
-    display: 'flex', alignItems: 'center', gap: 8, width: '100%', border: 'none', background: 'transparent',
+    display: 'flex', alignItems: 'center', gap: 8, width: '100%', border: 'none', background: 'var(--kb-mibg, transparent)',
     borderRadius: 7, padding: '7px 10px', fontSize: 13, color: C.text, cursor: 'pointer', textAlign: 'left',
   } as CSSProperties,
   menuItemDanger: { color: C.danger } as CSSProperties,
@@ -233,7 +312,10 @@ export const style = {
   } as CSSProperties,
   switchOn: { background: C.accent } as CSSProperties,
   switchKnob: {
-    position: 'absolute', top: 2, left: 2, width: 16, height: 16, borderRadius: '50%', background: '#fff',
+    position: 'absolute', top: 2, left: 2, width: 16, height: 16, borderRadius: '50%',
+    // Contrasts with the accent track in both themes (near-black knob on the
+    // near-white accent in dark mode, near-white knob on dark accent in light).
+    background: 'var(--dsw-alias-label-primary-foreground, #fff)',
     transition: 'transform 0.15s',
   } as CSSProperties,
   accordionHeader: {
@@ -267,9 +349,14 @@ export const style = {
     cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
     color: '#fff', padding: 0, flexShrink: 0, fontSize: 11, lineHeight: 1,
   } as CSSProperties,
-  checkboxOn: { background: C.accent, borderColor: C.accent } as CSSProperties,
+  checkboxOn: {
+    background: C.accent, borderColor: C.accent,
+    color: 'var(--dsw-alias-label-primary-foreground, #fff)',
+  } as CSSProperties,
   sidePanelScrim: {
-    position: 'absolute', inset: 0, zIndex: 30, background: 'rgba(0,0,0,0.28)',
+    // Less transparent scrim so the drawer clearly separates from the
+    // panel behind it (nothing reads through).
+    position: 'absolute', inset: 0, zIndex: 30, background: 'rgba(0,0,0,0.58)',
     display: 'flex', justifyContent: 'flex-end',
   } as CSSProperties,
   sidePanel: {
@@ -302,15 +389,25 @@ export function formatSize(charCount: number): string {
   return `${(charCount / (1024 * 1024)).toFixed(2)} MB`
 }
 
-/** Compact relative time, Cherry Studio style (刚刚 / N 分钟前 / N 小时前…). */
-export function formatRelativeTime(timestamp: number, now: number = Date.now()): string {
+/**
+ * Compact relative time, locale-aware via the bound translate (the old
+ * implementation hardcoded Chinese “刚刚 / N 分钟前…” which leaked into the
+ * English UI). now is only overridable for tests.
+ */
+export function formatRelativeTime(
+  timestamp: number,
+  // Narrow key union keeps this callable with the bound Translate
+  // ((key: KnowledgeKey) => string) while staying decoupled from locales.
+  t: (key: 'timeJustNow' | 'timeMinutes' | 'timeHours' | 'timeDays') => string,
+  now: number = Date.now(),
+): string {
   const diff = Math.max(0, now - timestamp)
   const minutes = Math.floor(diff / 60000)
-  if (minutes < 1) return '刚刚'
-  if (minutes < 60) return `${minutes} 分钟前`
+  if (minutes < 1) return t('timeJustNow')
+  if (minutes < 60) return t('timeMinutes').replace('{n}', String(minutes))
   const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours} 小时前`
+  if (hours < 24) return t('timeHours').replace('{n}', String(hours))
   const days = Math.floor(hours / 24)
-  if (days < 30) return `${days} 天前`
+  if (days < 30) return t('timeDays').replace('{n}', String(days))
   return new Date(timestamp).toLocaleDateString()
 }


### PR DESCRIPTION
## Summary

Enables importing a knowledge base from a **local path** (single file or directory tree), tracks **where each base's content came from** (source origin shown under the base name), and fixes several UI issues in the client.

## What's included

**Server / core**
- `importFromPath` (file or directory), `importFileFromPath` (single file), `setBaseSourcePath` to repoint a base's source path — with server-side validation of the path.
- New HTTP routes: `POST /documents/import-path` and `/documents/source-path`.
- `BaseSourceInfo` (bounded list of source-origin lines) and `storedDocCount` (docs with a persisted raw copy) added to base summaries.
- Raw-store hygiene: orphan raw copies left by failed/duplicate imports are reconciled and removed.

**Client / UI**
- `PopoverMenu` (rendered via `createPortal`) now tracks its own menu ref, so clicks on menu items are no longer misread as outside-clicks — this fixes menu buttons that never fired.
- The menu auto-flips above/below the trigger and closes on scroll/resize.
- Base provenance (source path/URL) displayed in the detail header; chunk badge uses a theme-aware color.
- `theme.ts`: `kb-primary`/`kb-danger-primary` tokens so hover/active states are readable in both light and dark DSH themes.

**Fixes / housekeeping**
- `embed.ts`: Ollama defaults an empty base URL to `http://127.0.0.1:11434` (kept consistent with the v0.3.8 `withAbortSignal` local-worker fix).
- `tool-knowledge`: aggregate `storedDocCount` in stats; build updates for the new types.
- `pnpm-workspace`: enable `tesseract.js` build.

Built cleanly (`tsc --noEmit` and `node build.mjs`) against v0.3.8.