### PR TITLE
feat(knowledge): import from local path + base source tracking

### DIFF
--- a/src/knowledge/http.ts
+++ b/src/knowledge/http.ts
@@ -308,6 +308,12 @@ async function route(
       if (segments[2] === 'import-directory-tree' && method === 'POST') {
         return service.importDirectoryTree(baseId, typeof body.path === 'string' ? body.path : '')
       }
+      if (segments[2] === 'import-path' && method === 'POST') {
+        return service.importFromPath(baseId, typeof body.path === 'string' ? body.path : '')
+      }
+      if (segments[2] === 'source-path' && method === 'POST') {
+        return service.setBaseSourcePath(baseId, typeof body.path === 'string' ? body.path : '')
+      }
       if (segments[2] === 'directories' && method === 'POST') {
         return service.createDirectory(
           baseId,

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -1234,10 +1234,14 @@ export class KnowledgeService extends Service {
   }
 
   /**
-   * Repoint a base's source: set `sourcePath` on every top-level directory
-   * container (path must be an existing directory), or on every top-level file
-   * document (path must be an existing file) when the base has no directory
-   * root. Used by the pencil button next to the base's source line.
+   * Repoint a base's source. The target set is chosen by the KIND of the
+   * passed path, not by whichever roots happen to exist: an existing
+   * DIRECTORY repoints every top-level directory container, an existing FILE
+   * repoints every top-level file document. This lets a mixed base — several
+   * imported directory roots plus a couple of single-file imports — repoint
+   * just the file source even when directory roots are present (previously the
+   * presence of any directory root made the file repoint fail with
+   * "not a directory"). Used by the pencil button next to the base's source line.
    */
   async setBaseSourcePath(baseId: string, path: string): Promise<{ set: number }> {
     const store = this.requireStore()
@@ -1251,17 +1255,15 @@ export class KnowledgeService extends Service {
       throw new Error(`path not found: ${trimmed}`)
     }
     const roots = store.listDocuments(baseId).filter(doc => doc.parentDirectoryId === undefined)
-    const dirRoots = roots.filter(doc => doc.sourceType === 'directory')
-    const fileRoots = roots.filter(doc => doc.sourceType === 'file')
     let targets: KnowledgeDocument[]
-    if (dirRoots.length > 0) {
-      if (!st.isDirectory()) throw new Error(`not a directory: ${trimmed}`)
-      targets = dirRoots
-    } else if (fileRoots.length > 0) {
-      if (!st.isFile()) throw new Error(`not a file: ${trimmed}`)
-      targets = fileRoots
+    if (st.isDirectory()) {
+      targets = roots.filter(doc => doc.sourceType === 'directory')
+      if (targets.length === 0) throw new Error('base has no directory source to repoint')
+    } else if (st.isFile()) {
+      targets = roots.filter(doc => doc.sourceType === 'file')
+      if (targets.length === 0) throw new Error('base has no file source to repoint')
     } else {
-      throw new Error('base has no directory or file source to repoint')
+      throw new Error(`not a file or directory: ${trimmed}`)
     }
     for (const doc of targets) {
       await store.putDocument({ ...doc, sourcePath: trimmed, updatedAt: Date.now() })

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -58,6 +58,7 @@ import type {
   AddFilesResult,
   AddTextDocumentRequest,
   BaseConfig,
+  BaseSourceInfo,
   BaseStats,
   BaseSummary,
   CreateBaseRequest,
@@ -664,16 +665,20 @@ export class KnowledgeService extends Service {
       const chunkCount = documents.reduce((sum, doc) => sum + doc.chunkCount, 0)
       const charCount = documents.reduce((sum, doc) => sum + doc.charCount, 0)
       const tokenCount = documents.reduce((sum, doc) => sum + (doc.tokenCount ?? 0), 0)
+      const storedDocCount = documents.reduce((sum, doc) => sum + (doc.rawFilePath !== undefined ? 1 : 0), 0)
+      const sourceInfo = baseSourceLines(documents)
       return {
         id: base.id,
         name: base.name,
         description: base.description,
         ...(base.group !== undefined ? { group: base.group } : {}),
         documentCount: documents.length,
+        storedDocCount,
         chunkCount,
         charCount,
         tokenCount,
         ...(base.config !== undefined ? { config: base.config } : {}),
+        ...(sourceInfo.length > 0 ? { sourceInfo } : {}),
         createdAt: base.createdAt,
         updatedAt: base.updatedAt,
       }
@@ -1029,20 +1034,29 @@ export class KnowledgeService extends Service {
           continue
         }
         // Cherry's prepare-root: persist a raw copy (base-relative path) so
-        // the base stays rebuildable if the source disk changes.
+        // the base stays rebuildable if the source disk changes. The stored
+        // path is derived from a fresh uuid (not the source file name) so two
+        // roots containing the same relative path can never collide.
         let rawFilePath: string | undefined
         const store = this.requireStore()
         if (store.raw !== undefined) {
-          rawFilePath = await store.raw.writeRel(job.baseId, basename(file), buffer)
+          rawFilePath = await store.raw.write(job.baseId, crypto.randomUUID(), safeRawExtension(basename(file)), buffer)
         }
-        await this.ingestDocument({
-          baseId: job.baseId,
-          title: basename(file),
-          sourceType: 'file',
-          fileName: basename(file),
-          rawFilePath,
-          text,
-        })
+        try {
+          await this.ingestDocument({
+            baseId: job.baseId,
+            title: basename(file),
+            sourceType: 'file',
+            fileName: basename(file),
+            rawFilePath,
+            text,
+          })
+        } catch (error) {
+          // A rejected item (e.g. duplicate content) must not leave an
+          // orphaned raw copy behind.
+          if (rawFilePath !== undefined) await store.raw?.delete(rawFilePath)
+          throw error
+        }
         job.imported += 1
       } catch (error) {
         job.errors.push({ file, error: error instanceof Error ? error.message : String(error) })
@@ -1120,22 +1134,30 @@ export class KnowledgeService extends Service {
             const text = await parseDocumentBuffer(buffer, basename(full))
             if (text.trim().length === 0) continue
             // Cherry's prepare-root: the base owns a stable copy of every
-            // imported file under raw/ (tree-relative path), so a later
-            // reindex rebuilds from the base even if the source disk changes.
+            // imported file under raw/, so a later reindex rebuilds from the
+            // base even if the source disk changes. The stored path is a fresh
+            // uuid (not the tree-relative path) so two roots that share a
+            // relative path never collide in raw storage.
             let rawFilePath: string | undefined
             if (store.raw !== undefined) {
-              const relPath = relative(path, full).replace(/\\/g, '/')
-              rawFilePath = await store.raw.writeRel(baseId, relPath, buffer)
+              rawFilePath = await store.raw.write(baseId, crypto.randomUUID(), safeRawExtension(basename(full)), buffer)
             }
-            await this.ingestDocument({
-              baseId,
-              title: basename(full),
-              sourceType: 'file',
-              fileName: basename(full),
-              parentDirectoryId: parentId,
-              rawFilePath,
-              text,
-            })
+            try {
+              await this.ingestDocument({
+                baseId,
+                title: basename(full),
+                sourceType: 'file',
+                fileName: basename(full),
+                parentDirectoryId: parentId,
+                rawFilePath,
+                text,
+              })
+            } catch (error) {
+              // A rejected item (e.g. duplicate content) must not leave an
+              // orphaned raw copy behind.
+              if (rawFilePath !== undefined) await store.raw?.delete(rawFilePath)
+              throw error
+            }
             imported += 1
           } catch (error) {
             errors.push({ file: full, error: error instanceof Error ? error.message : String(error) })
@@ -1146,6 +1168,105 @@ export class KnowledgeService extends Service {
 
     await walk(path, rootId, 0)
     return { imported, directories, errors }
+  }
+
+  /** Import a single local file by its absolute path (server-side). */
+  async importFileFromPath(baseId: string, filePath: string): Promise<{ imported: boolean; title: string }> {
+    const store = this.requireStore()
+    if (store.getBase(baseId) === undefined) throw new Error(`knowledge base not found: ${baseId}`)
+    const name = basename(filePath)
+    if (!SUPPORTED_DOCUMENT_EXTENSION_SET.has(extensionOf(name))) {
+      throw new Error(`Unsupported knowledge file type: ${name}`)
+    }
+    const buffer = await readFile(filePath)
+    const text = await parseDocumentBuffer(buffer, name)
+    if (text.trim().length === 0) throw new Error(`file is empty or unreadable: ${filePath}`)
+    // Persist a stable raw copy (Cherry's "import means copy") so the base
+    // stays rebuildable even if the source file changes or disappears. The
+    // stored path is a fresh uuid so it never collides with another import of
+    // the same file name.
+    let rawFilePath: string | undefined
+    if (store.raw !== undefined) {
+      rawFilePath = await store.raw.write(baseId, crypto.randomUUID(), safeRawExtension(name), buffer)
+    }
+    try {
+      await this.ingestDocument({
+        baseId,
+        title: name,
+        sourceType: 'file',
+        fileName: name,
+        rawFilePath,
+        sourcePath: filePath,
+        text,
+      })
+    } catch (error) {
+      // A rejected item (e.g. duplicate content) must not leave an orphaned
+      // raw copy behind.
+      if (rawFilePath !== undefined) await store.raw?.delete(rawFilePath)
+      throw error
+    }
+    return { imported: true, title: name }
+  }
+
+  /**
+   * Import a local path (directory tree or single file) by its absolute path,
+   * validating that it exists first. Directories reuse the tree import, which
+   * records `sourcePath` on every container so reindex rescans the disk.
+   */
+  async importFromPath(baseId: string, path: string): Promise<{ kind: 'directory' | 'file'; imported: number }> {
+    const trimmed = path.trim()
+    if (trimmed.length === 0) throw new Error('path is required')
+    let st
+    try {
+      st = await stat(trimmed)
+    } catch {
+      throw new Error(`path not found: ${trimmed}`)
+    }
+    if (st.isDirectory()) {
+      const result = await this.importDirectoryTree(baseId, trimmed)
+      return { kind: 'directory', imported: result.imported }
+    }
+    if (st.isFile()) {
+      await this.importFileFromPath(baseId, trimmed)
+      return { kind: 'file', imported: 1 }
+    }
+    throw new Error(`not a file or directory: ${trimmed}`)
+  }
+
+  /**
+   * Repoint a base's source: set `sourcePath` on every top-level directory
+   * container (path must be an existing directory), or on every top-level file
+   * document (path must be an existing file) when the base has no directory
+   * root. Used by the pencil button next to the base's source line.
+   */
+  async setBaseSourcePath(baseId: string, path: string): Promise<{ set: number }> {
+    const store = this.requireStore()
+    if (store.getBase(baseId) === undefined) throw new Error(`knowledge base not found: ${baseId}`)
+    const trimmed = path.trim()
+    if (trimmed.length === 0) throw new Error('path is required')
+    let st
+    try {
+      st = await stat(trimmed)
+    } catch {
+      throw new Error(`path not found: ${trimmed}`)
+    }
+    const roots = store.listDocuments(baseId).filter(doc => doc.parentDirectoryId === undefined)
+    const dirRoots = roots.filter(doc => doc.sourceType === 'directory')
+    const fileRoots = roots.filter(doc => doc.sourceType === 'file')
+    let targets: KnowledgeDocument[]
+    if (dirRoots.length > 0) {
+      if (!st.isDirectory()) throw new Error(`not a directory: ${trimmed}`)
+      targets = dirRoots
+    } else if (fileRoots.length > 0) {
+      if (!st.isFile()) throw new Error(`not a file: ${trimmed}`)
+      targets = fileRoots
+    } else {
+      throw new Error('base has no directory or file source to repoint')
+    }
+    for (const doc of targets) {
+      await store.putDocument({ ...doc, sourcePath: trimmed, updatedAt: Date.now() })
+    }
+    return { set: targets.length }
   }
 
   async addUrlDocument(request: ImportUrlRequest): Promise<KnowledgeDocument> {
@@ -1325,7 +1446,7 @@ export class KnowledgeService extends Service {
     // Fall back to the persisted text (then to reconstructed chunks) when the
     // file is gone or unreadable — a reindex must never wipe vectors for a
     // source that cannot be rebuilt.
-    const text = await this.sourceTextOf(document)
+    const { text, rawFilePath: nextRawFilePath } = await this.sourceTextOf(document)
     const config = this.getConfigFor(document.baseId)
     // Mark the document incomplete so a crash mid-reindex is resumed on the
     // next start (buildChunks persists each embedded batch; hash reuse makes
@@ -1335,6 +1456,9 @@ export class KnowledgeService extends Service {
     const { embeddingError: _staleError, errorCode: _staleCode, incomplete: _staleIncomplete, contentHash: _staleHash, ...rest } = document
     const next: KnowledgeDocument = {
       ...rest,
+      // A refreshed raw copy (e.g. sourceTextOf re-read a repointed sourcePath)
+      // must win over the stale stored path.
+      ...(nextRawFilePath !== undefined ? { rawFilePath: nextRawFilePath } : {}),
       rawText: text,
       contentHash: sha256(text),
       charCount: text.length,
@@ -1358,15 +1482,44 @@ export class KnowledgeService extends Service {
     return next
   }
 
-  /** Rebuild source text of a document: raw file first, then persisted text, then chunks. */
-  private async sourceTextOf(document: KnowledgeDocument): Promise<string> {
+  /** Rebuild source text of a document. A path-imported single file (sourcePath)
+   *  is re-read from disk first so EDITS and a repointed source (setBaseSourcePath)
+   *  are picked up, refreshing the persisted raw copy; otherwise the raw copy,
+   *  then persisted text, then reconstructed chunks are used. Returns the rebuilt
+   *  text and, when the raw copy was refreshed, its new base-relative path. */
+  private async sourceTextOf(document: KnowledgeDocument): Promise<{ text: string; rawFilePath?: string }> {
+    const store = this.requireStore()
+    // A single-file path import tracks its live source on disk. Reindex re-reads
+    // that path so edits and a repointed source (setBaseSourcePath) are actually
+    // applied — the old behavior rebuilt only from the persisted raw copy and
+    // ignored sourcePath. An unreadable path falls through to the stored copy.
+    if (document.sourceType === 'file' && document.sourcePath !== undefined) {
+      try {
+        const buffer = await readFile(document.sourcePath)
+        if (buffer.byteLength > 0) {
+          const text = await parseDocumentBuffer(buffer, document.fileName ?? document.title, document.mimeType)
+          if (text.trim().length > 0) {
+            if (store.raw !== undefined) {
+              const fileName = document.fileName ?? document.title
+              const nextRaw = await store.raw.write(document.baseId, document.id, safeRawExtension(fileName), buffer)
+              if (nextRaw !== document.rawFilePath && document.rawFilePath !== undefined) {
+                await store.raw.delete(document.rawFilePath)
+              }
+              return { text, rawFilePath: nextRaw }
+            }
+            return { text }
+          }
+        }
+      } catch (error) {
+        this.ctx.logger.warn(`knowledge: re-reading source path failed, falling back to stored copy: ${error instanceof Error ? error.message : String(error)}`)
+      }
+    }
     if (document.rawFilePath !== undefined) {
-      const store = this.requireStore()
       const raw = await store.raw?.read(document.rawFilePath)
       if (raw !== null && raw !== undefined && raw.byteLength > 0) {
         try {
           const text = await parseDocumentBuffer(raw, document.fileName ?? document.title, document.mimeType)
-          if (text.trim().length > 0) return text
+          if (text.trim().length > 0) return { text }
         } catch (error) {
           this.ctx.logger.warn(`knowledge: re-parsing raw source failed, falling back to stored text: ${error instanceof Error ? error.message : String(error)}`)
         }
@@ -1376,7 +1529,7 @@ export class KnowledgeService extends Service {
     }
     const text = document.rawText ?? reconstructFromChunks(this.requireStore().listChunksByDoc(document.id))
     if (text.trim().length === 0) throw new Error(`document "${document.title}" has no source text to reindex`)
-    return text
+    return { text }
   }
 
   /**
@@ -1385,7 +1538,9 @@ export class KnowledgeService extends Service {
    * - files/directories removed from disk are deleted from the base,
    * - new supported files are parsed and ingested (raw copy persisted),
    * - new subdirectories become containers (with their own sourcePath),
-   * - existing items are re-indexed (re-chunk + hash-reuse re-embed).
+   * - existing items are re-indexed (re-chunk + hash-reuse re-embed); when
+   *   the on-disk bytes differ from the base's persisted raw copy, the copy
+   *   is refreshed first so EDITS to source files are picked up too.
    * A missing/unreadable source keeps the existing subtree untouched (Cherry
    * skips roots whose source cannot be rebuilt). Failures are isolated per
    * entry and summarized at the end.
@@ -1464,35 +1619,71 @@ export class KnowledgeService extends Service {
         try {
           if (existing !== undefined) {
             if (this.indexing.has(existing.id)) continue
+            // Content sync with the disk: reindex alone rebuilds from the
+            // base's persisted raw copy, so edits to a source file were never
+            // picked up. When the on-disk bytes differ from the stored copy,
+            // refresh the copy and re-index from the NEW content. Equal bytes
+            // fall through to the plain reindex (rebuild from the stored
+            // copy); a failed disk read must never wipe the stored copy or
+            // the existing vectors, so it also falls through unchanged.
+            if (store.raw !== undefined && existing.rawFilePath !== undefined) {
+              try {
+                const buffer = await readFile(full)
+                const stored = await store.raw.read(existing.rawFilePath)
+                const changed = stored === null || stored === undefined || stored.byteLength === 0
+                  || !Buffer.from(stored).equals(buffer)
+                if (changed) {
+                  const text = await parseDocumentBuffer(buffer, entry.name)
+                  // Never replace a good snapshot with empty/unreadable new
+                  // content: keep the stored copy and the old vectors.
+                  if (text.trim().length > 0) {
+                    // rawFilePath already carries the `<baseId>/` prefix (it is
+                    // the full base-relative path), so strip it before writeRel,
+                    // which prepends `<baseId>/` again — otherwise the refreshed
+                    // bytes land at a doubled path and the following reindex still
+                    // rebuilds from the stale stored copy.
+                    const relRaw = existing.rawFilePath.startsWith(`${document.baseId}/`)
+                      ? existing.rawFilePath.slice(document.baseId.length + 1)
+                      : existing.rawFilePath
+                    await store.raw.writeRel(document.baseId, relRaw, buffer)
+                    await this.reindexDocument(existing.id)
+                    continue
+                  }
+                }
+              } catch {
+                // Disk or raw read failed: fall back to the stored-copy
+                // reindex below (the copy and vectors stay intact).
+              }
+            }
             await this.reindexDocument(existing.id)
           } else {
             // New file: parse + ingest like an import, with a persisted raw
-            // copy (tree-relative path) so a later reindex can rebuild from
-            // the base even if the source disk changes.
+            // copy so a later reindex can rebuild from the base even if the
+            // source disk changes. The stored path is a fresh uuid (not the
+            // tree-relative path) so it cannot collide with a sibling root's
+            // file that happens to share the same relative path.
             const buffer = await readFile(full)
             const text = await parseDocumentBuffer(buffer, entry.name)
             if (text.trim().length === 0) continue
             let rawFilePath: string | undefined
             if (store.raw !== undefined) {
-              // Resolve the outermost root's source path so the stored
-              // relative path matches the initial import's layout.
-              let root = document
-              while (root.parentDirectoryId !== undefined) {
-                const parent = store.getDocument(root.parentDirectoryId)
-                if (parent === undefined || parent.sourceType !== 'directory') break
-                root = parent
+              rawFilePath = await store.raw.write(document.baseId, crypto.randomUUID(), safeRawExtension(entry.name), buffer)
+              try {
+                await this.ingestDocument({
+                  baseId: document.baseId,
+                  title: entry.name,
+                  sourceType: 'file',
+                  fileName: entry.name,
+                  parentDirectoryId: document.id,
+                  rawFilePath,
+                  text,
+                })
+              } catch (error) {
+                // A rejected item (e.g. duplicate content) must not leave an
+                // orphaned raw copy behind.
+                await store.raw.delete(rawFilePath)
+                throw error
               }
-              const relPath = relative(root.sourcePath ?? source, full).replace(/\\/g, '/')
-              rawFilePath = await store.raw.writeRel(document.baseId, relPath, buffer)
-              await this.ingestDocument({
-                baseId: document.baseId,
-                title: entry.name,
-                sourceType: 'file',
-                fileName: entry.name,
-                parentDirectoryId: document.id,
-                rawFilePath,
-                text,
-              })
             } else {
               await this.ingestDocument({
                 baseId: document.baseId,
@@ -2213,6 +2404,7 @@ export class KnowledgeService extends Service {
     return {
       ...(baseId !== undefined ? { baseId } : {}),
       documentCount: documents.length,
+      storedDocCount: documents.reduce((sum, doc) => sum + (doc.rawFilePath !== undefined ? 1 : 0), 0),
       chunkCount: chunkStats.count,
       charCount,
       tokenCount,
@@ -2747,6 +2939,8 @@ export class KnowledgeService extends Service {
     text: string
     /** Base-relative path of the persisted original source bytes (file docs). */
     rawFilePath?: string
+    /** Absolute source path the item was imported from (file/path imports). */
+    sourcePath?: string
     /** Pre-created placeholder id (already stored, shown while embedding). */
     placeholderId?: string
   }, signal?: AbortSignal): Promise<KnowledgeDocument> {
@@ -2791,6 +2985,7 @@ export class KnowledgeService extends Service {
         ...(input.url !== undefined ? { url: input.url } : {}),
         ...(input.parentDirectoryId !== undefined ? { parentDirectoryId: input.parentDirectoryId } : {}),
         ...(input.rawFilePath !== undefined ? { rawFilePath: input.rawFilePath } : {}),
+        ...(input.sourcePath !== undefined ? { sourcePath: input.sourcePath } : {}),
         contentHash,
         rawText: input.text,
         charCount: input.text.length,
@@ -3069,6 +3264,39 @@ function effectiveMode(requested: SearchMode, ranked: readonly RankedHit[]): Sea
   if (requested === 'hybrid') return hybrid ? 'hybrid' : 'lexical'
   // auto
   return hybrid ? 'hybrid' : 'lexical'
+}
+
+/** Bounded list of a base's top-level sources (directory roots / files / URLs /
+ *  text nodes), for the detail header. Nested children are covered by their
+ *  root, so only `parentDirectoryId === undefined` items are listed. */
+function baseSourceLines(documents: KnowledgeDocument[]): BaseSourceInfo[] {
+  const MAX = 4
+  const seen = new Set<string>()
+  const lines: BaseSourceInfo[] = []
+  for (const doc of documents) {
+    if (doc.parentDirectoryId !== undefined) continue
+    let kind: DocumentSourceType
+    let text: string
+    if (doc.sourceType === 'directory') {
+      kind = 'directory'
+      text = doc.sourcePath ?? doc.title
+    } else if (doc.sourceType === 'url') {
+      kind = 'url'
+      text = doc.url ?? doc.title
+    } else if (doc.sourceType === 'file') {
+      kind = 'file'
+      text = doc.sourcePath ?? doc.fileName ?? doc.title
+    } else {
+      kind = 'text'
+      text = 'node'
+    }
+    const key = `${kind}:${text}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    lines.push({ kind, text })
+    if (lines.length >= MAX) break
+  }
+  return lines
 }
 
 function sha256(text: string): string {

--- a/src/knowledge/store.ts
+++ b/src/knowledge/store.ts
@@ -10,8 +10,8 @@
  */
 
 import type { Domain, DomainSpec } from '@deepseek-ai/dsh-storage-domain'
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { dirname, extname, join } from 'node:path'
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { dirname, extname, join, relative } from 'node:path'
 import { knowledgeDomainSpec, TABLES } from './domain.js'
 import type { ConfigOverrides } from './domain.js'
 import { ChunkDatabase, hashEmbeddingText, legacyChunkFilePath, migrateLegacyChunkFile, resolveChunkStorePath, searchTextOf } from './chunkdb.js'
@@ -47,6 +47,8 @@ export interface RawFileStore {
   writeRel(baseId: string, relativePath: string, bytes: Uint8Array): Promise<string>
   /** Read a document's source bytes back (null when absent). */
   read(relativePath: string): Promise<Uint8Array | null>
+  /** Every stored base-relative path (for orphan-raw reconciliation). */
+  listAll(): Promise<string[]>
   /** Remove one document's source file by its stored relative path (missing = no-op). */
   delete(relativePath: string): Promise<void>
   /** Remove every source file of a base. */
@@ -90,6 +92,25 @@ export class RawFileStorage implements RawFileStore {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
       throw error
     }
+  }
+
+  async listAll(): Promise<string[]> {
+    const out: string[] = []
+    const walk = async (dir: string): Promise<void> => {
+      let entries
+      try {
+        entries = await readdir(dir, { withFileTypes: true })
+      } catch {
+        return
+      }
+      for (const entry of entries) {
+        const full = join(dir, entry.name)
+        if (entry.isDirectory()) await walk(full)
+        else out.push(relative(this.root, full).replace(/\\/g, '/'))
+      }
+    }
+    await walk(this.root)
+    return out
   }
 
   async delete(relativePath: string): Promise<void> {
@@ -153,6 +174,8 @@ export interface Store {
    *   before/during parse) — re-indexed by the service after startup.
    */
   recoverInterruptedImports(startedAt: number): Promise<{ removed: number; resume: string[] }>
+  /** Remove raw source copies no document references (orphans from failed/duplicate imports). */
+  reconcileOrphanRaws(): Promise<number>
   /** Aggregate chunk stats without loading chunk rows. */
   chunkStats(baseIds: readonly string[]): ChunkStats
   /** SQL-backed retrieval lanes (FTS5 + vector scan); absent on in-memory stores. */
@@ -220,6 +243,8 @@ export async function openStore(
       const recovery = await store.recoverInterruptedImports(Date.now())
       if (recovery.removed > 0) console.warn(`dsh-knowledge: removed ${recovery.removed} incomplete import(s) left by an interrupted run`)
       await store.reconcileChunkCounts()
+      const orphaned = await store.reconcileOrphanRaws()
+      if (orphaned > 0) console.warn(`dsh-knowledge: removed ${orphaned} orphaned raw source file(s) no document referenced`)
       return store
     } catch (error) {
       // Fall through to memory on any open failure (no backend, version mismatch, …).
@@ -379,6 +404,23 @@ class DomainStore implements Store {
 
   docChunkStatus(baseId: string): { withChunks: Set<string>; missingEmbedding: Set<string> } {
     return this.chunkDb.docChunkStatus(baseId)
+  }
+
+  async reconcileOrphanRaws(): Promise<number> {
+    const referenced = new Set<string>()
+    for (const base of this.listBases()) {
+      for (const doc of this.listDocuments(base.id)) {
+        if (doc.rawFilePath !== undefined) referenced.add(doc.rawFilePath)
+      }
+    }
+    let removed = 0
+    for (const rel of await this.rawStore.listAll()) {
+      if (!referenced.has(rel)) {
+        await this.rawStore.delete(rel)
+        removed += 1
+      }
+    }
+    return removed
   }
 
   chunkStats(baseIds: readonly string[]): ChunkStats {
@@ -591,6 +633,11 @@ class MemoryStore implements Store {
       removed += 1
     }
     return { removed, resume }
+  }
+
+  async reconcileOrphanRaws(): Promise<number> {
+    // In-memory store keeps no raw files on disk.
+    return 0
   }
 
   docChunkStatus(baseId: string): { withChunks: Set<string>; missingEmbedding: Set<string> } {

--- a/src/knowledge/types.ts
+++ b/src/knowledge/types.ts
@@ -315,6 +315,15 @@ export interface DocumentSummary {
   readonly updatedAt?: number
 }
 
+/** One origin line for a base: where its content came from (shown under the
+ *  base name in the detail header — path for directories/files, link for URLs,
+ *  "node" for manually added text). */
+export interface BaseSourceInfo {
+  readonly kind: DocumentSourceType
+  /** Directory path / file name / URL / 'node'. */
+  readonly text: string
+}
+
 /** Summary of one knowledge base, for listing UIs. */
 export interface BaseSummary {
   readonly id: string
@@ -322,10 +331,14 @@ export interface BaseSummary {
   readonly description: string
   readonly group?: string
   readonly documentCount: number
+  /** Documents with a persisted raw source copy (actually imported & stored). */
+  readonly storedDocCount: number
   readonly chunkCount: number
   readonly charCount: number
   readonly tokenCount: number
   readonly config?: BaseConfig
+  /** Top-level sources of the base's content, for display (bounded). */
+  readonly sourceInfo?: BaseSourceInfo[]
   readonly createdAt: number
   readonly updatedAt: number
 }
@@ -334,6 +347,8 @@ export interface BaseSummary {
 export interface BaseStats {
   readonly baseId?: string
   readonly documentCount: number
+  /** Documents with a persisted raw source copy (actually imported & stored). */
+  readonly storedDocCount: number
   readonly chunkCount: number
   readonly charCount: number
   readonly tokenCount: number

--- a/src/tool-knowledge/index.ts
+++ b/src/tool-knowledge/index.ts
@@ -50,11 +50,12 @@ const contextWindowSchema = {
 function aggregateStats(rows: ReadonlyArray<ReturnType<KnowledgeService['stats']>>): ReturnType<KnowledgeService['stats']> {
   return rows.reduce<ReturnType<KnowledgeService['stats']>>((total, row) => ({
     documentCount: total.documentCount + row.documentCount,
+    storedDocCount: total.storedDocCount + row.storedDocCount,
     chunkCount: total.chunkCount + row.chunkCount,
     charCount: total.charCount + row.charCount,
     tokenCount: total.tokenCount + row.tokenCount,
     embedded: total.embedded || row.embedded,
-  }), { documentCount: 0, chunkCount: 0, charCount: 0, tokenCount: 0, embedded: false })
+  }), { documentCount: 0, storedDocCount: 0, chunkCount: 0, charCount: 0, tokenCount: 0, embedded: false })
 }
 
 function clampToolInt(value: number | undefined, min: number, max: number, fallback: number): number {

--- a/src/ui/client/KnowledgeSection.tsx
+++ b/src/ui/client/KnowledgeSection.tsx
@@ -35,9 +35,12 @@ import {
 import {
   IconBook,
   IconCheck,
+  IconDoc,
   IconEye,
   IconFlask,
+  IconLink,
   IconMore,
+  IconPencil,
   IconPlus,
   IconRefresh,
   IconSearch,
@@ -139,6 +142,8 @@ type DialogState =
   | { kind: 'renameGroup'; group: string }
   | { kind: 'confirmDeleteGroup'; group: string }
   | { kind: 'addUrl' }
+  | { kind: 'addPath' }
+  | { kind: 'editSourcePath'; initial: string }
   | { kind: 'addText' }
   | null
 
@@ -193,6 +198,10 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
   const [localModelStatus, setLocalModelStatus] = useState<LocalModelStatus | null>(null)
   const [docLimit, setDocLimit] = useState(100)
   const [navWidth, setNavWidth] = useState(272)
+  // Sliding side panels (settings / recall test) are resizable too; the width
+  // is shared between them so the user's preference sticks while the panel is
+  // open.
+  const [sidePanelWidth, setSidePanelWidth] = useState(460)
   const [dragOver, setDragOver] = useState(false)
   const dragDepth = useRef(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -210,9 +219,16 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
   const notify = useCallback((kind: Toast['kind'], text: string): void => {
     const id = Date.now() + Math.random()
     setToasts(prev => [...prev, { id, kind, text }])
+    // Errors/warnings carry codes the user may need to copy, so they stay
+    // until dismissed manually; success/info auto-clear after a short delay.
+    if (kind === 'error' || kind === 'warning') return
     window.setTimeout(() => {
       setToasts(prev => prev.filter(toast => toast.id !== id))
     }, 3200)
+  }, [])
+
+  const dismissToast = useCallback((id: number): void => {
+    setToasts(prev => prev.filter(toast => toast.id !== id))
   }, [])
 
   const run = useCallback(async (fn: () => Promise<void>): Promise<void> => {
@@ -261,6 +277,22 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
     document.addEventListener('mousemove', onMove)
     document.addEventListener('mouseup', onUp)
   }, [navWidth])
+
+  const onSideResizeStart = useCallback((event: React.MouseEvent): void => {
+    event.preventDefault()
+    const startX = event.clientX
+    const startWidth = sidePanelWidth
+    const onMove = (ev: MouseEvent): void => {
+      // Panel sits on the right edge; dragging left grows it, right shrinks.
+      setSidePanelWidth(Math.min(680, Math.max(360, startWidth - (ev.clientX - startX))))
+    }
+    const onUp = (): void => {
+      document.removeEventListener('mousemove', onMove)
+      document.removeEventListener('mouseup', onUp)
+    }
+    document.addEventListener('mousemove', onMove)
+    document.addEventListener('mouseup', onUp)
+  }, [sidePanelWidth])
 
   // Local embedding readiness, for the empty-state guidance.
   useEffect(() => {
@@ -511,6 +543,51 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
       }
     })
   }, [api, run, onImported, notify, selectedBaseId, currentDirectoryId])
+
+  const promptForPath = useCallback((): void => {
+    if (selectedBaseId === null) return
+    setDialog({ kind: 'addPath' })
+  }, [selectedBaseId])
+
+  const addPath = useCallback((path: string): void => {
+    if (selectedBaseId === null) return
+    const trimmed = path.trim()
+    if (trimmed === '') return
+    void run(async () => {
+      try {
+        const result = await api.importFromPath(selectedBaseId, trimmed)
+        setDialog(null)
+        notify('success', `${t('tabPath')}: ${result.kind === 'directory' ? `${result.imported} ${t('docCount')}` : result.imported}`)
+        await refreshBases()
+        await reloadDocuments()
+      } catch (err) {
+        notify('error', err instanceof Error ? err.message : String(err))
+      }
+    })
+  }, [api, run, refreshBases, reloadDocuments, notify, selectedBaseId, t])
+
+  const promptForSourcePath = useCallback((): void => {
+    if (selectedBaseId === null) return
+    const currentBase = bases.find(base => base.id === selectedBaseId)
+    const current = currentBase?.sourceInfo?.map(source => source.text).find(Boolean) ?? ''
+    setDialog({ kind: 'editSourcePath', initial: current })
+  }, [bases, selectedBaseId])
+
+  const editSourcePath = useCallback((path: string): void => {
+    if (selectedBaseId === null) return
+    const trimmed = path.trim()
+    if (trimmed === '') return
+    void run(async () => {
+      try {
+        const result = await api.setBaseSourcePath(selectedBaseId, trimmed)
+        setDialog(null)
+        notify('success', `${t('sourcePathEdit')}: ${result.set}`)
+        await refreshBases()
+      } catch (err) {
+        notify('error', err instanceof Error ? err.message : String(err))
+      }
+    })
+  }, [api, run, refreshBases, notify, selectedBaseId, t])
 
   const addText = useCallback((title: string, content: string): void => {
     if (selectedBaseId === null) return
@@ -895,7 +972,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
             apiKey: config.apiKey,
           })
         } catch (error) {
-          notify('error', `${t('dimensionProbeFailed')}：${error instanceof Error ? error.message : String(error)}`)
+          notify('error', `${t('dimensionProbeFailed')}: ${error instanceof Error ? error.message : String(error)}`)
           return
         }
       }
@@ -1047,6 +1124,15 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
     { key: 'delete', label: t('delete'), danger: true, onSelect: () => setDialog({ kind: 'confirmDeleteGroup', group }) },
   ]
 
+  const baseSourceGlyph = (kind: 'text' | 'file' | 'url' | 'directory'): JSX.Element => {
+    switch (kind) {
+      case 'directory': return <IconFolderOpen size={12} />
+      case 'url': return <IconLink size={12} />
+      case 'file': return <IconDoc size={12} />
+      default: return <IconPencil size={12} />
+    }
+  }
+
   const renderBaseRow = (base: BaseSummary): JSX.Element => (
     <div
       key={base.id}
@@ -1076,6 +1162,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
   const addSourceMenu: MenuEntry[] = [
     { key: 'file', label: t('tabFile'), onSelect: () => fileInputRef.current?.click() },
     { key: 'dir', label: t('tabDir'), onSelect: () => dirInputRef.current?.click() },
+    { key: 'path', label: t('tabPath'), onSelect: () => promptForPath() },
     { key: 'url', label: t('tabUrl'), onSelect: () => promptForUrl() },
     { key: 'text', label: t('tabText'), onSelect: () => setDialog({ kind: 'addText' }) },
   ]
@@ -1130,7 +1217,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
         </span>
       </div>
 
-      <Toasts toasts={toasts} />
+      <Toasts toasts={toasts} onDismiss={dismissToast} />
 
       <div style={style.body}>
         <aside style={{ ...style.sidebar, width: navWidth }} className="kb-scroll">
@@ -1188,9 +1275,11 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
         </aside>
 
         <div
+          className="kb-sash"
           onMouseDown={onNavResizeStart}
-          style={{ width: 5, cursor: 'col-resize', flexShrink: 0, background: 'transparent', borderRight: `1px solid ${C.border}` }}
+          style={{ width: 8, cursor: 'col-resize', flexShrink: 0, background: 'transparent', borderRight: `1px solid ${C.border}` }}
           title={t('dragResize')}
+          aria-label={t('dragResize')}
         />
 
         <main style={style.main} className="kb-scroll">
@@ -1249,6 +1338,29 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                 </span>
               </div>
 
+              {/* Base origin(s), between the name and the stats: directory
+                  path / file / URL / node for manually added text. The pencil
+                  repoints the base's source path (validated server-side). */}
+              {(selectedBase.sourceInfo ?? []).length > 0 && (
+                <div style={style.baseSourceRow}>
+                  {selectedBase.sourceInfo!.map((source, i) => (
+                    <span key={i} style={style.baseSourceItem}>
+                      <span style={style.baseSourceGlyph}>{baseSourceGlyph(source.kind)}</span>
+                      <span style={style.baseSourceText} title={source.text}>{source.text}</span>
+                    </span>
+                  ))}
+                  <button
+                    className="kb-iconbtn"
+                    style={{ ...style.baseSourceEdit, ...style.iconOnlyButton }}
+                    title={t('sourcePathEdit')}
+                    aria-label={t('sourcePathEdit')}
+                    onClick={promptForSourcePath}
+                  >
+                    <IconPencil size={11} />
+                  </button>
+                </div>
+              )}
+
               {selectedDocId !== null && selectedDoc !== null ? (
                 <DocumentDetailPanel
                   key={selectedDoc.id}
@@ -1265,7 +1377,8 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                 <>
                   {stats !== null && (
                     <div style={style.statsRow}>
-                      <StatChip value={stats.documentCount} label={t('statsDocs')} />
+                      <StatChip value={stats.documentCount} label={t('statsSourceDocs')} title={t('statsSourceDocsTitle')} />
+                      <StatChip value={stats.storedDocCount} label={t('statsStoredDocs')} title={t('statsStoredDocsTitle')} />
                       <StatChip value={stats.chunkCount} label={t('statsChunks')} />
                       <StatChip value={stats.tokenCount} label={t('statsTokens')} />
                       <StatChip value={formatSize(stats.charCount)} label={t('statsChars')} />
@@ -1300,7 +1413,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                         background: 'color-mix(in srgb, var(--dsw-alias-brand-primary, #3b6ef6) 8%, transparent)',
                         borderRadius: 10, pointerEvents: 'none',
                       }}>
-                        <span style={{ fontSize: 14, fontWeight: 600, color: C.accent, background: 'var(--dsw-bg-base, #fff)', padding: '8px 16px', borderRadius: 999, boxShadow: '0 2px 10px rgba(0,0,0,0.12)' }}>
+                        <span style={{ fontSize: 14, fontWeight: 600, color: C.accent, background: C.bg, padding: '8px 16px', borderRadius: 999, boxShadow: '0 2px 10px rgba(0,0,0,0.12)' }}>
                           {t('dragToUpload')}
                         </span>
                       </div>
@@ -1319,7 +1432,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                             <IconRefresh size={13} />{t('bulkReindex')}
                           </button>
                           <button
-                            style={style.primaryDanger}
+                            className="kb-danger-primary" style={style.primaryDanger}
                             disabled={busy}
                             onClick={() => setDialog({ kind: 'confirmBulkDelete', count: checkedDocs.length })}
                           >
@@ -1331,7 +1444,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                         <span style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
                           <span style={{ fontSize: 11, color: C.muted }}>
-                            {t('updatedAtText')} {formatRelativeTime(selectedBase.updatedAt)}
+                            {t('updatedAtText')} {formatRelativeTime(selectedBase.updatedAt, t)}
                           </span>
                           {selectedBaseLocalModel !== null && localModelStatus !== null && localModelStatus.status !== 'ready' && (
                             <span
@@ -1360,7 +1473,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                         </span>
                         <PopoverMenu
                           align="end"
-                          trigger={<button style={style.primary} disabled={busy}><IconPlus />{t('addSource')}</button>}
+                          trigger={<button className="kb-primary" style={style.primary} disabled={busy}><IconPlus />{t('addSource')}</button>}
                           entries={addSourceMenu}
                         />
                       </div>
@@ -1382,7 +1495,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                               <div style={{ display: 'flex', justifyContent: 'center' }}>
                                 <PopoverMenu
                                   align="start"
-                                  trigger={<button style={style.primary} disabled={busy}><IconPlus />{t('addSource')}</button>}
+                                  trigger={<button className="kb-primary" style={style.primary} disabled={busy}><IconPlus />{t('addSource')}</button>}
                                   entries={addSourceMenu}
                                 />
                               </div>
@@ -1547,7 +1660,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                                         style={{ display: 'inline-flex', alignItems: 'center', gap: 3, fontSize: 11, color: C.danger }}
                                         tabIndex={0}
                                         role="img"
-                                        aria-label={`${t('embeddingFailed')}：${reason}`}
+                                        aria-label={`${t('embeddingFailed')}: ${reason}`}
                                         title={reason}
                                       >
                                         ✕ {t('embeddingFailed')}
@@ -1564,7 +1677,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                                   )
                                 })()}
                                 <span style={{ fontSize: 11, color: C.muted }}>
-                                  {doc.updatedAt !== undefined ? formatRelativeTime(doc.updatedAt) : ''}
+                                  {doc.updatedAt !== undefined ? formatRelativeTime(doc.updatedAt, t) : ''}
                                 </span>
                                 <PopoverMenu
                                   align="end"
@@ -1576,7 +1689,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                             {hasMoreDocuments && (
                               <div style={{ display: 'flex', justifyContent: 'center', padding: '10px 0 4px' }}>
                                 <button className="kb-row" style={style.button} onClick={() => setDocLimit(v => v + 100)}>
-                                  {t('loadMore')}（{renderedDocuments.length}/{visibleDocuments.length}）
+                                  {t('loadMore')} ({renderedDocuments.length}/{visibleDocuments.length})
                                 </button>
                               </div>
                             )}
@@ -1595,7 +1708,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
         </main>
 
         {ragOpen && globalConfig !== null && selectedBase !== null && (
-          <SidePanel title={t('baseSettings')} onClose={() => setRagOpen(false)}>
+          <SidePanel title={t('baseSettings')} onClose={() => setRagOpen(false)} width={sidePanelWidth} onResizeWidth={onSideResizeStart}>
             <RagConfigPanel
               base={selectedBase}
               globalConfig={globalConfig}
@@ -1608,7 +1721,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
         )}
 
         {recallOpen && selectedBase !== null && (
-          <SidePanel title={t('recallTest')} onClose={() => setRecallOpen(false)}>
+          <SidePanel title={t('recallTest')} onClose={() => setRecallOpen(false)} width={sidePanelWidth} onResizeWidth={onSideResizeStart}>
             <RecallPanel
               t={t}
               busy={busy}
@@ -1722,6 +1835,24 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
           onClose={() => setDialog(null)}
         />
       )}
+      {dialog?.kind === 'addPath' && (
+        <PromptDialog
+          title={t('tabPath')}
+          label={t('pathDesc')}
+          initial=""
+          onOk={(value) => { setDialog(null); addPath(value) }}
+          onClose={() => setDialog(null)}
+        />
+      )}
+      {dialog?.kind === 'editSourcePath' && (
+        <PromptDialog
+          title={t('sourcePathEdit')}
+          label={t('sourcePathPrompt')}
+          initial={dialog.initial}
+          onOk={(value) => { setDialog(null); editSourcePath(value) }}
+          onClose={() => setDialog(null)}
+        />
+      )}
       {dialog?.kind === 'addText' && (
         <TextDocumentDialog
           t={t}
@@ -1758,10 +1889,10 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
               </ul>
             )}
             <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
-              <button style={style.primary} disabled={pendingResolution !== null} onClick={() => resolveConflict('rename')}>
+              <button className="kb-primary" style={style.primary} disabled={pendingResolution !== null} onClick={() => resolveConflict('rename')}>
                 {pendingResolution === 'rename' ? t('resolvingConflict') : t('conflictKeepAll')}
               </button>
-              <button style={style.primaryDanger} disabled={pendingResolution !== null} onClick={() => resolveConflict('replace')}>
+              <button className="kb-danger-primary" style={style.primaryDanger} disabled={pendingResolution !== null} onClick={() => resolveConflict('replace')}>
                 {pendingResolution === 'replace' ? t('resolvingConflict') : t('conflictReplaceAll')}
               </button>
               <button style={style.button} disabled={pendingResolution !== null} onClick={() => resolveConflict('cancel')}>
@@ -1838,11 +1969,11 @@ function failureReasonLabel(doc: DocumentSummary, t: Translate): string {
     case 'interrupted':
       return t('errorInterrupted')
     case 'dimension_mismatch':
-      return `${t('errorDimensionMismatch')}：${doc.embeddingError ?? ''}`
+      return `${t('errorDimensionMismatch')}: ${doc.embeddingError ?? ''}`
     case 'parse_failed':
-      return `${t('errorParseFailed')}：${doc.embeddingError ?? ''}`
+      return `${t('errorParseFailed')}: ${doc.embeddingError ?? ''}`
     case 'embedding_provider':
-      return `${t('errorEmbeddingProvider')}：${doc.embeddingError ?? ''}`
+      return `${t('errorEmbeddingProvider')}: ${doc.embeddingError ?? ''}`
     default:
       return doc.embeddingError ?? t('embeddingFailed')
   }
@@ -1895,7 +2026,7 @@ function RecallPanel(props: {
             >🕘</button>
           )}
         </div>
-        <button style={style.primary} disabled={!canSearch} onClick={() => props.onSearch(props.searchQuery)}>⚡{t('searchButton')}</button>
+        <button className="kb-primary" style={style.primary} disabled={!canSearch} onClick={() => props.onSearch(props.searchQuery)}>⚡{t('searchButton')}</button>
 
         {hasHistory && historyOpen && (
           <div style={{ position: 'absolute', top: 'calc(100% + 4px)', left: 0, right: 0, zIndex: 40, maxHeight: 220, overflowY: 'auto', background: C.overlay, border: `1px solid ${C.border}`, borderRadius: 10, boxShadow: '0 10px 32px rgba(0,0,0,0.18)', padding: 4 }}>
@@ -1964,7 +2095,7 @@ function RecallResultCard(props: { hit: SearchHit; index: number; t: Translate }
     try {
       // Copy a full Markdown citation (quote + source) so the excerpt can be
       // pasted into the conversation with its traceable source line.
-      await navigator.clipboard.writeText(citationMarkdown(hit))
+      await navigator.clipboard.writeText(citationMarkdown(hit, t))
       setCopied(true)
       window.setTimeout(() => setCopied(false), 2000)
     } catch {
@@ -1998,23 +2129,47 @@ function RecallResultCard(props: { hit: SearchHit; index: number; t: Translate }
   )
 }
 
-function SidePanel(props: { title: string; onClose: () => void; children: React.ReactNode }): JSX.Element {
+function SidePanel(props: {
+  title: string
+  onClose: () => void
+  children: React.ReactNode
+  width?: number
+  onResizeWidth?: (event: React.MouseEvent) => void
+}): JSX.Element {
+  const resizable = props.onResizeWidth !== undefined
   return (
     <div style={style.sidePanelScrim} onClick={props.onClose}>
-      <div style={style.sidePanel} onClick={(e) => e.stopPropagation()}>
-        <div style={style.sidePanelHeader}>
-          <span style={{ fontSize: 14, fontWeight: 600 }}>{props.title}</span>
-          <button className="kb-row" style={style.closeButton} onClick={props.onClose} aria-label="close">✕</button>
+      <div
+        style={{ ...style.sidePanel, width: props.width ?? 460, flexDirection: 'row' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {resizable && (
+          <div
+            className="kb-sash"
+            onMouseDown={props.onResizeWidth}
+            style={{
+              width: 8, cursor: 'col-resize', flexShrink: 0, alignSelf: 'stretch',
+              position: 'relative', zIndex: 6, borderRight: `1px solid ${C.border}`,
+            }}
+            title="Drag to resize"
+            aria-label="Drag to resize"
+          />
+        )}
+        <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+          <div style={style.sidePanelHeader}>
+            <span style={{ fontSize: 14, fontWeight: 600 }}>{props.title}</span>
+            <button className="kb-row" style={style.closeButton} onClick={props.onClose} aria-label="close">✕</button>
+          </div>
+          <div style={style.sidePanelBody} className="kb-scroll">{props.children}</div>
         </div>
-        <div style={style.sidePanelBody} className="kb-scroll">{props.children}</div>
       </div>
     </div>
   )
 }
 
-function StatChip(props: { value: string | number; label: string }): JSX.Element {
+function StatChip(props: { value: string | number; label: string; title?: string }): JSX.Element {
   return (
-    <span style={style.statChip}>
+    <span style={style.statChip} title={props.title}>
       <span style={style.statValue}>{props.value}</span>
       <span style={style.statLabel}>{props.label}</span>
     </span>
@@ -2290,7 +2445,7 @@ function DocumentDetailPanel(props: {
                 return (
                   <div key={chunk.id} style={{ border: `1px solid ${C.border}`, borderRadius: 8, marginBottom: 8, background: C.surface }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px', borderBottom: `1px solid ${C.border}` }}>
-                      <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', minWidth: 20, height: 20, padding: '0 6px', borderRadius: 5, background: C.accent, color: '#fff', fontSize: 11, fontWeight: 600 }}>{chunk.index + 1}</span>
+                      <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', minWidth: 20, height: 20, padding: '0 6px', borderRadius: 5, background: C.accent, color: 'var(--dsw-alias-label-primary-foreground, #fff)', fontSize: 11, fontWeight: 600 }}>{chunk.index + 1}</span>
                       <span style={{ flex: 1, minWidth: 0, fontSize: 11, color: C.muted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {chunk.heading !== undefined ? chunk.heading : ''}
                       </span>
@@ -2338,12 +2493,12 @@ function scoreColor(score: number, palette: typeof C): string {
 }
 
 /** Markdown citation block for one search hit: quote + source line. */
-function citationMarkdown(hit: SearchHit): string {
+function citationMarkdown(hit: SearchHit, t: Translate): string {
   const quote = hit.text.split('\n').map(line => `> ${line}`).join('\n')
   const source = hit.heading !== undefined && hit.heading.length > 0
     ? `${hit.documentTitle} / ${hit.heading}`
     : hit.documentTitle
-  return `${quote}\n>\n> — ${source}（知识库 ${hit.baseId}）`
+  return `${quote}\n>\n> — ${source}${t('citationSource').replace('{id}', hit.baseId)}`
 }
 
 function highlightMatches(text: string, query: string, markStyle: CSSProperties): JSX.Element {

--- a/src/ui/client/api.ts
+++ b/src/ui/client/api.ts
@@ -42,16 +42,29 @@ export interface BaseConfig {
   resumeInterruptedOnStartup?: boolean
 }
 
+/** One origin line for a base: where its content came from (shown under the
+ *  base name in the detail header — path for directories/files, link for URLs,
+ *  "node" for manually added text). */
+export interface BaseSourceInfo {
+  kind: 'text' | 'file' | 'url' | 'directory'
+  /** Directory path / file name / URL / 'node'. */
+  text: string
+}
+
 export interface BaseSummary {
   id: string
   name: string
   description: string
   group?: string
   documentCount: number
+  /** Documents with a persisted raw source copy (actually imported & stored). */
+  storedDocCount: number
   chunkCount: number
   charCount: number
   tokenCount: number
   config?: BaseConfig
+  /** Top-level sources of the base's content, for display (bounded). */
+  sourceInfo?: BaseSourceInfo[]
   createdAt: number
   updatedAt: number
 }
@@ -232,6 +245,8 @@ export interface RerankStatus {
 export interface BaseStats {
   baseId?: string
   documentCount: number
+  /** Documents with a persisted raw source copy (actually imported & stored). */
+  storedDocCount: number
   chunkCount: number
   charCount: number
   tokenCount: number
@@ -275,14 +290,16 @@ interface Envelope<T> {
 }
 
 export class KnowledgeApi {
-  private async call<T>(method: string, path: string, body?: unknown): Promise<T> {
+  private async call<T>(method: string, path: string, body?: unknown, timeoutMs = 60_000): Promise<T> {
     const response = await fetch(`/knowledge${path}`, {
       method,
       headers: body !== undefined ? { 'content-type': 'application/json' } : undefined,
       body: body !== undefined ? JSON.stringify(body) : undefined,
       // A hung host must not pin the panel's busy state forever: fail the
-      // call with a clear error instead of an indefinite spinner.
-      signal: AbortSignal.timeout(60_000),
+      // call with a clear error instead of an indefinite spinner. Long-running
+      // jobs (reindex of a whole base) pass a larger budget so a slow sweep is
+      // not cut short while the server is still working.
+      signal: AbortSignal.timeout(timeoutMs),
     })
     let envelope: Envelope<T>
     try {
@@ -517,6 +534,16 @@ export class KnowledgeApi {
     return this.call('POST', `/bases/${encodeURIComponent(baseId)}/import-directory-tree`, { baseId, path })
   }
 
+  /** Import a local directory or single file by its absolute path (validated server-side). */
+  importFromPath(baseId: string, path: string): Promise<{ kind: 'directory' | 'file'; imported: number }> {
+    return this.call('POST', `/bases/${encodeURIComponent(baseId)}/import-path`, { baseId, path })
+  }
+
+  /** Repoint the base's source path (validated server-side). */
+  setBaseSourcePath(baseId: string, path: string): Promise<{ set: number }> {
+    return this.call('POST', `/bases/${encodeURIComponent(baseId)}/source-path`, { baseId, path })
+  }
+
   getDirectoryImport(jobId: string): Promise<DirectoryImportStatus> {
     return this.call('GET', `/import-directory/${encodeURIComponent(jobId)}`)
   }
@@ -541,7 +568,7 @@ export class KnowledgeApi {
   }
 
   reindexDocument(documentId: string): Promise<{ id: string; chunkCount: number }> {
-    return this.call('POST', `/documents/${encodeURIComponent(documentId)}/reindex`)
+    return this.call('POST', `/documents/${encodeURIComponent(documentId)}/reindex`, undefined, 30 * 60_000)
   }
 
   refreshUrlDocument(documentId: string): Promise<{ changed: boolean; title: string; chunkCount: number }> {
@@ -549,7 +576,7 @@ export class KnowledgeApi {
   }
 
   reindexDocuments(ids: string[]): Promise<{ reindexed: number; skipped: number }> {
-    return this.call('POST', '/documents/reindex', { ids })
+    return this.call('POST', '/documents/reindex', { ids }, 30 * 60_000)
   }
 
   deleteDocument(id: string): Promise<{ deleted: boolean }> {

--- a/tests/domain-store.spec.ts
+++ b/tests/domain-store.spec.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { Domain, KvTable } from '@deepseek-ai/dsh-storage-domain'
 import { Context } from '@deepseek-ai/cordis'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { knowledgeDomainSpec } from '../src/knowledge/domain.js'
 import { ChunkDatabase, hashEmbeddingText, migrateLegacyChunkFile } from '../src/knowledge/chunkdb.js'
 import { openStore } from '../src/knowledge/store.js'
-import type { StorageDomainFacility } from '../src/knowledge/store.js'
+import type { StorageDomainFacility, Store } from '../src/knowledge/store.js'
 import { KnowledgeService } from '../src/knowledge/index.js'
 import type { Config } from '../src/knowledge/config.js'
 import type { KnowledgeChunk } from '../src/knowledge/types.js'
@@ -800,6 +800,111 @@ describe('KnowledgeService restart', () => {
         expect(service2.getConfig().localModelCacheDir).toBe(resolve(modelsDir))
       } finally {
         await closeStore(service2)
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('local-path import source tracking', () => {
+  const decode = (bytes: Uint8Array | null): string => bytes !== null ? new TextDecoder().decode(bytes) : ''
+  const mount = async (dir: string): Promise<KnowledgeService> => {
+    const ctx = new Context()
+    ctx.provide('webServer', { routes: [], register: () => () => {} })
+    ctx.provide('storageDomain', { open: async () => fakeDomain() })
+    await ctx.plugin(KnowledgeService, { ...TEST_CONFIG, chunkStorePath: join(dir, 'chunks.sqlite') })
+    return ctx.get('knowledge') as KnowledgeService
+  }
+  const closeStore = async (service: KnowledgeService): Promise<void> => {
+    await (service as unknown as { store: { close(): Promise<void> } }).store.close()
+  }
+  const storeOf = (service: KnowledgeService): Store =>
+    (service as unknown as { store: Store }).store
+
+  it('reindexes a single-file path import from the repointed sourcePath', async () => {
+    const dir = await tempDir()
+    try {
+      vi.stubEnv('DSH_HOME', dir)
+      const src1 = join(dir, 'a.txt')
+      const src2 = join(dir, 'b.txt')
+      await writeFile(src1, 'alpha content', 'utf8')
+      await writeFile(src2, 'beta content', 'utf8')
+
+      const service = await mount(dir)
+      try {
+        const base = await service.createBase({ name: 'src' })
+        await service.importFromPath(base.id, src1)
+        const store = storeOf(service)
+        const doc = store.listDocuments(base.id).find(d => d.sourceType === 'file')
+        expect(doc).toBeDefined()
+        expect(doc!.rawText).toContain('alpha')
+        expect(doc!.sourcePath).toBe(src1)
+        const beforeHash = doc!.contentHash
+
+        // Repoint the source to a different file and reindex: the reindex must
+        // rebuild from the NEW path (previously it re-read the old raw copy).
+        await service.setBaseSourcePath(base.id, src2)
+        await service.reindexDocument(doc!.id)
+        const reindexed = store.getDocument(doc!.id)
+        expect(reindexed).toBeDefined()
+        expect(reindexed!.rawText).toContain('beta')
+        expect(reindexed!.contentHash).not.toBe(beforeHash)
+        expect(reindexed!.sourcePath).toBe(src2)
+        // The persisted raw copy was refreshed to the new file's bytes.
+        expect(decode(await store.raw!.read(reindexed!.rawFilePath!))).toContain('beta')
+      } finally {
+        await closeStore(service)
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps raw copies distinct when two directory roots share a relative path', async () => {
+    const dir = await tempDir()
+    try {
+      vi.stubEnv('DSH_HOME', dir)
+      const rootA = join(dir, 'rootA')
+      const rootB = join(dir, 'rootB')
+      await mkdir(join(rootA, 'docs'), { recursive: true })
+      await mkdir(join(rootB, 'docs'), { recursive: true })
+      await writeFile(join(rootA, 'docs', 'report.txt'), 'report from A', 'utf8')
+      await writeFile(join(rootB, 'docs', 'report.txt'), 'report from B', 'utf8')
+
+      const service = await mount(dir)
+      try {
+        const base = await service.createBase({ name: 'collide' })
+        await service.importFromPath(base.id, rootA)
+        await service.importFromPath(base.id, rootB)
+        const store = storeOf(service)
+        const docs = store.listDocuments(base.id).filter(d => d.sourceType === 'file')
+        expect(docs).toHaveLength(2)
+
+        // Both files share the relative path docs/report.txt, but each must own
+        // a distinct raw copy whose bytes match its own source (no collision).
+        const raws = new Set<string>()
+        const contents: string[] = []
+        for (const doc of docs) {
+          expect(doc.rawFilePath).toBeDefined()
+          raws.add(doc.rawFilePath!)
+          contents.push(decode(await store.raw!.read(doc.rawFilePath!)))
+        }
+        expect(raws.size).toBe(2)
+        expect(contents).toEqual(expect.arrayContaining(['report from A', 'report from B']))
+
+        // Removing report.txt from rootA and rescanning rootA must delete A's
+        // doc and its raw copy, but leave rootB's cached raw untouched.
+        await rm(join(rootA, 'docs', 'report.txt'))
+        const rootAId = store.listDocuments(base.id)
+          .find(d => d.sourceType === 'directory' && d.title === 'rootA')!.id
+        await service.reindexDocument(rootAId)
+        const remaining = store.listDocuments(base.id).filter(d => d.sourceType === 'file')
+        expect(remaining).toHaveLength(1)
+        const survivor = store.listDocuments(base.id).filter(d => d.sourceType === 'file')[0]
+        expect(decode(await store.raw!.read(survivor.rawFilePath!))).toContain('B')
+      } finally {
+        await closeStore(service)
       }
     } finally {
       await rm(dir, { recursive: true, force: true })

--- a/tests/domain-store.spec.ts
+++ b/tests/domain-store.spec.ts
@@ -853,6 +853,26 @@ describe('local-path import source tracking', () => {
         expect(reindexed!.sourcePath).toBe(src2)
         // The persisted raw copy was refreshed to the new file's bytes.
         expect(decode(await store.raw!.read(reindexed!.rawFilePath!))).toContain('beta')
+
+        // Mixed-base repoint: with a directory root present, a FILE repoint must
+        // still select the top-level files (not the directories).
+        const mixed = join(dir, 'mixed')
+        await mkdir(join(mixed, 'sub'), { recursive: true })
+        await writeFile(join(mixed, 'sub', 'c.txt'), 'c content', 'utf8')
+        await writeFile(join(dir, 'd.txt'), 'delta content', 'utf8')
+        await service.importFromPath(base.id, mixed)      // adds a directory root
+        await service.importFromPath(base.id, join(dir, 'd.txt')) // adds a top-level file
+        const dDoc = store.listDocuments(base.id).find(d => d.sourceType === 'file' && d.fileName === 'd.txt')
+        expect(dDoc).toBeDefined()
+        const src3 = join(dir, 'e.txt')
+        await writeFile(src3, 'epsilon content', 'utf8')
+        await service.setBaseSourcePath(base.id, src3)    // a FILE path now repoints files
+        await service.reindexDocument(dDoc!.id)
+        expect(store.getDocument(dDoc!.id)!.rawText).toContain('epsilon')
+        // The directory root was NOT touched by the file repoint.
+        const dirRoot = store.listDocuments(base.id).find(d => d.sourceType === 'directory')
+        expect(dirRoot).toBeDefined()
+        expect(dirRoot!.sourcePath).toBe(mixed)
       } finally {
         await closeStore(service)
       }


### PR DESCRIPTION
## Summary
Server-side local path import (single file or directory tree), base provenance in summaries, raw-store hygiene, and a repointable source path — with the review feedback addressed.

> Please merge in order: this PR depends on `feat/locales` and `feat/ui-theme-interaction`.

## What's included
- **Server / core**
  - `importFromPath` (file or directory), `importFileFromPath` (single file), `setBaseSourcePath` to repoint a base's source; new routes `POST /documents/import-path` and `/documents/source-path`; server-side path validation.
  - `BaseSourceInfo` (source-origin lines) and `storedDocCount` (docs with a persisted raw copy) in base summaries; surfaced in the detail header.
  - Raw-store hygiene: `reconcileOrphanRaws` removes raw copies no document references.
- **Client / UI**
  - `KnowledgeSection.tsx` — path-import tab, source-info header with an edit-source-path pencil, `statsSourceDocs`/`statsStoredDocs` chips; adopts the new `formatRelativeTime` signature and the `kb-*` theme classes.

## Review feedback addressed (merge blockers)
1. **Single-file sourcePath repoint now takes effect on reindex.** `sourceTextOf` re-reads the file at `sourcePath` (instead of always rebuilding from the stale raw copy), refreshes the persisted raw copy, and threads the new `rawFilePath` through `reindexDocument`.
2. **No raw-store collision between directory roots.** Path imports persist raw copies at a fresh-uuid path (`store.raw.write`) instead of the tree-relative path (`writeRel`), so two roots sharing a relative path can no longer collide or have one root's rescan delete the other's cached copy. `writeRel` remains only for refreshing an existing doc's copy during rescan content sync. Also: `setBaseSourcePath` now selects its target by the type of the passed path, so a file repoint works in a base that also has directory roots.
3. **Packaging policy** — the accidental `tesseract.js: true` flip is not included here (`pnpm-workspace.yaml` stays `false` on `main`), so `scripts/verify-build-policy.mjs` stays green.

## Regression tests
Added in `tests/domain-store.spec.ts` (`local-path import source tracking`):
- single-file `sourcePath` repoint → reindex reflects the new file (incl. mixed base with directory roots);
- two directory roots sharing `docs/report.txt` keep distinct raw copies, and rescanning one root leaves the other's copy intact.

## Merge order
Merge after `feat/locales` and `feat/ui-theme-interaction`.

## Testing
- `pnpm run typecheck` — clean against `main` + `feat/locales` + `feat/ui-theme-interaction`.
- `pnpm exec vitest run tests/domain-store.spec.ts` — 24/24 pass.
