### PR TITLE
feat(ui): theme tokens, portal popover menu and interaction fixes

### DIFF
--- a/src/ui/client/LocalModelsSection.tsx
+++ b/src/ui/client/LocalModelsSection.tsx
@@ -125,7 +125,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
   const browseCacheDir = useCallback(async (): Promise<void> => {
     setError(null)
     if (props.workspaces === undefined) {
-      setError('文件夹选择不可用（当前环境无目录选择能力）')
+      setError(t('cacheDirPickUnavailable'))
       return
     }
     try {
@@ -134,7 +134,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     }
-  }, [props.workspaces])
+  }, [props.workspaces, t])
 
   const openCacheDir = useCallback(async (): Promise<void> => {
     setError(null)
@@ -155,7 +155,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
       setCacheDir(result.to)
       setError(null)
       if (result.moved > 0) {
-        setError(`${result.moved} 个模型目录已迁移到 ${result.to}`)
+        setError(t('cacheDirMigrated').replace('{count}', String(result.moved)).replace('{to}', result.to))
       } else {
         // Also silent before: a no-op migration (same dir, or the target
         // already holds the entries) showed nothing at all.
@@ -180,6 +180,24 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
       setOllamaBusy(false)
     }
   }, [api, ollamaBase, t])
+
+  // Make the Ollama server used here the global embedding default, so new
+  // bases inherit it (per-base settings only override it). Non-fatal on
+  // error — model management must keep working even if persistence fails.
+  const persistOllamaDefault = useCallback((): void => {
+    const base = ollamaBase.trim()
+    if (base === '') return
+    void api.setConfig({ embeddingProvider: 'ollama', embeddingBaseUrl: base }).catch(() => {})
+    // Also default the embedding model so a fresh base embeds out of the box:
+    // the first installed embedding model (or a recommended one) becomes the
+    // global default only while none is configured yet.
+    void api.getConfig().then(current => {
+      if ((current.embeddingModel ?? '').trim() !== '') return
+      const candidate = [...ollamaSuggestions.ollamaEmbedding, ...ollamaInstalled.map(m => m.name)]
+        .find(name => /embed|bge|mxbai|e5|gte|nomic/i.test(name))
+      if (candidate !== undefined) void api.setConfig({ embeddingModel: candidate }).catch(() => {})
+    }).catch(() => {})
+  }, [api, ollamaBase, ollamaInstalled, ollamaSuggestions])
 
   // Live Ollama pull progress (polled only while a pull is actually running).
   // The moment a pull leaves the `pulling` state its card clears and, on
@@ -252,6 +270,14 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
     setError(null)
     try {
       await api.pullOllamaModel(model, ollamaBase)
+      // Pulling from an Ollama server makes it the global embedding default
+      // (provider + URL), so new bases inherit it instead of reconfiguring.
+      persistOllamaDefault()
+      // If the pulled model is an embedding model, also set it as the global
+      // embedding-model default.
+      if (ollamaSuggestions.ollamaEmbedding.includes(model) || /embed|bge|mxbai|e5|gte|nomic/i.test(model)) {
+        void api.setConfig({ embeddingModel: model }).catch(() => {})
+      }
       setPullingModels(prev => prev.some(p => p.model === model)
         ? prev
         : [...prev, { model, status: 'pulling', progress: 0, message: '' }])
@@ -264,7 +290,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
       setError(`${err instanceof Error ? err.message : String(err)} ${t('ollamaNeedInstall')}`)
       setOllamaBusy(false)
     }
-  }, [api, ollamaModel, ollamaBase, t])
+  }, [api, ollamaModel, ollamaBase, ollamaSuggestions, persistOllamaDefault, t])
 
   const cancelOllama = useCallback(async (model: string): Promise<void> => {
     try {
@@ -559,7 +585,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
             value={ollamaBase}
             onChange={(e) => setOllamaBase(e.target.value)}
           />
-          <button className="kb-btn" style={style.button} disabled={ollamaBusy} onClick={() => void refreshOllamaTags()}>
+          <button className="kb-btn" style={style.button} disabled={ollamaBusy} onClick={() => { persistOllamaDefault(); void refreshOllamaTags() }}>
             <IconRefresh size={13} />{t('ollamaRefresh')}
           </button>
         </div>

--- a/src/ui/client/dialogs.tsx
+++ b/src/ui/client/dialogs.tsx
@@ -20,7 +20,7 @@ export interface Toast {
   text: string
 }
 
-export function Toasts(props: { toasts: readonly Toast[] }): JSX.Element | null {
+export function Toasts(props: { toasts: readonly Toast[]; onDismiss?: (id: number) => void }): JSX.Element | null {
   if (props.toasts.length === 0) return null
   return (
     <div style={style.toastStack}>
@@ -33,7 +33,10 @@ export function Toasts(props: { toasts: readonly Toast[] }): JSX.Element | null 
               : toast.kind === 'warning'
                 ? <IconX size={14} color="#f5a524" />
                 : null}
-          <span>{toast.text}</span>
+          <span style={{ userSelect: 'text', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{toast.text}</span>
+          <button style={style.toastClose} onClick={() => props.onDismiss?.(toast.id)} aria-label="close">
+            <IconX size={12} color={C.muted} />
+          </button>
         </div>
       ))}
     </div>
@@ -77,7 +80,7 @@ export function ConfirmDialog(props: {
       <p style={{ fontSize: 13, margin: '0 0 16px', lineHeight: 1.6 }}>{props.message}</p>
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>✕</button>
-        <button style={style.primaryDanger} onClick={props.onConfirm} disabled={props.busy === true}>{props.confirmLabel}</button>
+        <button className="kb-danger-primary" style={style.primaryDanger} onClick={props.onConfirm} disabled={props.busy === true}>{props.confirmLabel}</button>
       </div>
     </Modal>
   )
@@ -116,7 +119,7 @@ export function PromptDialog(props: {
       </div>
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>✕</button>
-        <button style={style.primary} disabled={submitting || value.trim().length === 0} onClick={submit}>OK</button>
+        <button className="kb-primary" style={style.primary} disabled={submitting || value.trim().length === 0} onClick={submit}>OK</button>
       </div>
     </Modal>
   )
@@ -157,7 +160,7 @@ export function TextDocumentDialog(props: {
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>{props.t('cancel')}</button>
         <button
-          style={style.primary}
+          className="kb-primary" style={style.primary}
           disabled={props.busy === true || title.trim().length === 0 || content.trim().length === 0}
           onClick={() => props.onCreate(title.trim(), content)}
         >
@@ -200,11 +203,17 @@ export function RestoreBaseDialog(props: {
       </div>
       <div style={style.field}>
         <label style={style.label}>{props.t('embeddingModel')}</label>
-        <select style={style.input} value={provider} onChange={(e) => setProvider(e.target.value as typeof provider)}>
+        <select style={style.input} value={provider} onChange={(e) => {
+          const next = e.target.value as typeof provider
+          // Auto-fill the well-known local Ollama endpoint when the user
+          // switches to Ollama, so the URL is not retyped by hand.
+          if (next === 'ollama' && baseUrl.trim() === '') setBaseUrl('http://127.0.0.1:11434')
+          setProvider(next)
+        }}>
           <option value="none">{props.t('restoreKeepModel')}</option>
-          <option value="openai">OpenAI 兼容</option>
+          <option value="openai">{props.t('providerOpenAI')}</option>
           <option value="ollama">Ollama</option>
-          <option value="local">本地模型</option>
+          <option value="local">{props.t('providerLocal')}</option>
         </select>
       </div>
       {modelChanged && (
@@ -257,7 +266,7 @@ export function RestoreBaseDialog(props: {
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>{props.t('cancel')}</button>
         <button
-          style={style.primary}
+          className="kb-primary" style={style.primary}
           disabled={props.busy === true || name.trim().length === 0 || (modelChanged && model.trim().length === 0)}
           onClick={() => props.onRestore(
             name.trim(),
@@ -308,7 +317,7 @@ export function CreateBaseDialog(props: {
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>{props.t('cancel')}</button>
         <button
-          style={style.primary}
+          className="kb-primary" style={style.primary}
           disabled={props.busy === true || name.trim().length === 0}
           onClick={() => props.onCreate(name.trim(), description.trim(), group.trim() === '' ? undefined : group.trim())}
         >

--- a/src/ui/client/popover.tsx
+++ b/src/ui/client/popover.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type { ReactNode } from 'react'
 import { style } from './theme.js'
 
@@ -26,38 +27,107 @@ export function PopoverMenu(props: {
 }): JSX.Element {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
+  // The menu renders in a body-level portal, OUTSIDE ref — track it too so
+  // clicks on menu items are not treated as outside-clicks (otherwise the
+  // mousedown dismissal unmounts the menu before the item's click fires and
+  // every menu action silently dies).
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [pos, setPos] = useState<{ top: number; left?: number; right?: number } | null>(null)
 
   useEffect(() => {
     if (!open) return
     const onDocumentClick = (event: MouseEvent): void => {
-      if (ref.current !== null && !ref.current.contains(event.target as Node)) setOpen(false)
+      const target = event.target as Node
+      if (ref.current !== null && ref.current.contains(target)) return
+      if (menuRef.current !== null && menuRef.current.contains(target)) return
+      setOpen(false)
     }
+    const onScroll = (): void => setOpen(false)
+    const onResize = (): void => setOpen(false)
     document.addEventListener('mousedown', onDocumentClick)
-    return () => document.removeEventListener('mousedown', onDocumentClick)
+    window.addEventListener('scroll', onScroll, true)
+    window.addEventListener('resize', onResize)
+    return () => {
+      document.removeEventListener('mousedown', onDocumentClick)
+      window.removeEventListener('scroll', onScroll, true)
+      window.removeEventListener('resize', onResize)
+    }
   }, [open])
+
+  const toggle = (): void => {
+    const next = !open
+    setOpen(next)
+    if (next && ref.current !== null) {
+      const rect = ref.current.getBoundingClientRect()
+      // Open below the trigger; flip above when there isn't enough room below
+      // (menu is rendered in a body-level portal so it must stay in the viewport).
+      const est = estimateMenuHeight(props.entries)
+      const below = window.innerHeight - rect.bottom - 8
+      const above = rect.top - 8
+      const top = (below >= est || below >= above) ? rect.bottom + 4 : Math.max(8, rect.top - est - 4)
+      setPos({
+        top,
+        left: props.align === 'end' ? undefined : rect.left,
+        right: props.align === 'end' ? window.innerWidth - rect.right : undefined,
+      })
+    }
+  }
 
   return (
     <div ref={ref} style={{ position: 'relative', display: 'inline-flex' }}>
       <span
         style={{ display: 'inline-flex' }}
-        onClick={(e) => { e.stopPropagation(); setOpen(v => !v) }}
+        onClick={(e) => { e.stopPropagation(); toggle() }}
       >
         {props.trigger}
       </span>
-      {open && (
+      {open && pos !== null && createPortal(
         <div
-          style={{ ...style.menu, top: 'calc(100% + 4px)', ...(props.align === 'end' ? { right: 0 } : { left: 0 }) }}
+          ref={menuRef}
+          style={{
+            ...style.menu,
+            position: 'fixed',
+            top: pos.top,
+            left: pos.left,
+            right: pos.right,
+            // Body-level portal: sit above the whole panel (zIndex 300) so the
+            // menu can never be buried by list rows or clipped by a scrollable
+            // sidebar's overflow.
+            zIndex: 1000,
+          }}
           onClick={(e) => e.stopPropagation()}
         >
           <MenuItems entries={props.entries} onCloseAll={() => setOpen(false)} />
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   )
 }
 
+/** Rough menu height for deciding whether to open below vs above the trigger. */
+function estimateMenuHeight(entries: readonly MenuEntry[]): number {
+  let h = 8 // menu vertical padding
+  for (const e of entries) h += e.label === undefined ? 9 : 36 // separator vs item
+  return h
+}
+
 function MenuItems(props: { entries: readonly MenuEntry[]; onCloseAll: () => void }): JSX.Element {
   const [openSub, setOpenSub] = useState<string | null>(null)
+  const closeTimer = useRef<number | null>(null)
+  const cancelClose = (): void => {
+    if (closeTimer.current !== null) {
+      window.clearTimeout(closeTimer.current)
+      closeTimer.current = null
+    }
+  }
+  const scheduleClose = (): void => {
+    cancelClose()
+    closeTimer.current = window.setTimeout(() => setOpenSub(null), 150)
+  }
+  useEffect(() => () => {
+    if (closeTimer.current !== null) window.clearTimeout(closeTimer.current)
+  }, [])
   return (
     <>
       {props.entries.map(entry =>
@@ -65,11 +135,11 @@ function MenuItems(props: { entries: readonly MenuEntry[]; onCloseAll: () => voi
           ? <div key={entry.key} style={style.menuSeparator} />
           : (
               <div key={entry.key} style={{ position: 'relative' }}
-                onMouseEnter={() => entry.children !== undefined && setOpenSub(entry.key)}
-                onMouseLeave={() => { if (openSub === entry.key) setOpenSub(null) }}
+                onMouseEnter={() => { if (entry.children !== undefined) { cancelClose(); setOpenSub(entry.key) } }}
+                onMouseLeave={() => { if (openSub === entry.key) scheduleClose() }}
               >
                 <button
-                  className="kb-row"
+                  className="kb-row kb-menuitem"
                   style={{ ...style.menuItem, ...(entry.danger === true ? style.menuItemDanger : {}) }}
                   onClick={() => {
                     if (entry.children !== undefined) {
@@ -87,10 +157,13 @@ function MenuItems(props: { entries: readonly MenuEntry[]; onCloseAll: () => voi
                   {entry.children !== undefined && <span style={{ color: 'inherit', opacity: 0.55, fontSize: 10 }}>▸</span>}
                 </button>
                 {entry.children !== undefined && openSub === entry.key && (
-                  <div style={{ ...style.menu, top: -4, left: 'calc(100% + 4px)', position: 'absolute' }}>
+                  <div style={{ ...style.menu, top: 'calc(100% + 4px)', left: 0, position: 'absolute' }}
+                    onMouseEnter={cancelClose}
+                    onMouseLeave={scheduleClose}
+                  >
                     <MenuItems
                       entries={entry.children}
-                      onCloseAll={() => { setOpenSub(null); props.onCloseAll() }}
+                      onCloseAll={() => { cancelClose(); setOpenSub(null); props.onCloseAll() }}
                     />
                   </div>
                 )}

--- a/src/ui/client/rag-config.tsx
+++ b/src/ui/client/rag-config.tsx
@@ -185,7 +185,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
         }
       } catch (err) {
         setProbing(false)
-        setSaveError(`${t('dimensionProbeFailed')}：${err instanceof Error ? err.message : String(err)}`)
+        setSaveError(`${t('dimensionProbeFailed')}: ${err instanceof Error ? err.message : String(err)}`)
         return
       }
       setProbing(false)
@@ -223,7 +223,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
             onChange={(e) => patch({ documentProcessorProvider: e.target.value as 'builtin' | 'mineru' })}
           >
             <option value="builtin">{t('processorBuiltin')}</option>
-            <option value="mineru">MinerU（远程，扫描件/复杂版面）</option>
+            <option value="mineru">{t('mineruOption')}</option>
           </select>
           {values.documentProcessorProvider === 'mineru' && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
@@ -236,7 +236,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
               />
               <input
                 style={style.input}
-                placeholder="API Host（默认 https://mineru.net）"
+                placeholder={t('mineruHostPlaceholder')}
                 value={values.mineruApiHost}
                 onChange={(e) => patch({ mineruApiHost: e.target.value })}
               />
@@ -292,7 +292,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
                 ) : (
                   <input
                     style={style.input}
-                    placeholder="视觉模型（如 qwen-vl-plus、gpt-4o-mini）"
+                    placeholder={t('visionModelPlaceholder')}
                     value={values.imageCaptionModel}
                     onChange={(e) => patch({ imageCaptionModel: e.target.value })}
                   />
@@ -300,8 +300,8 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
                 <input
                   style={style.input}
                   placeholder={values.imageCaptionProvider === 'ollama'
-                    ? 'Ollama 地址（默认 http://127.0.0.1:11434）'
-                    : 'API 地址（留空用嵌入模型地址）'}
+                    ? t('captionBaseUrlOllamaPlaceholder')
+                    : t('captionBaseUrlPlaceholder')}
                   value={values.imageCaptionBaseUrl}
                   onChange={(e) => patch({ imageCaptionBaseUrl: e.target.value })}
                 />
@@ -343,7 +343,13 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
                 const next = ollamaEmbeddingModels.includes(values.embeddingModel)
                   ? values.embeddingModel
                   : (ollamaEmbeddingModels[0] ?? '')
-                patch({ embeddingProvider: provider, embeddingModel: next })
+                // Auto-fill the well-known local Ollama endpoint so a user
+                // creating a fresh base does not retype http://127.0.0.1:11434
+                // every time (the model name is already auto-picked).
+                const nextBase = values.embeddingBaseUrl.trim() === ''
+                  ? 'http://127.0.0.1:11434'
+                  : values.embeddingBaseUrl
+                patch({ embeddingProvider: provider, embeddingModel: next, embeddingBaseUrl: nextBase })
               } else {
                 // openai / none: free-text or none — keep whatever was typed.
                 patch({ embeddingProvider: provider })
@@ -683,7 +689,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
         >
           <IconRefresh size={13} />{t('reset')}
         </button>
-        <button style={style.primary} disabled={!dirty || busy || probing} onClick={() => void save()}>
+        <button className="kb-primary" style={style.primary} disabled={!dirty || busy || probing} onClick={() => void save()}>
           {probing ? t('dimensionProbing') : t('save')}
         </button>
       </div>

--- a/src/ui/client/react-dom.d.ts
+++ b/src/ui/client/react-dom.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Ambient declaration for the external `react-dom` module.
+ * `react-dom` is NOT installed here — the DSH shell injects it into the
+ * frozen client module table at runtime (see build.mjs clientExternal), so
+ * esbuild keeps it external. This declaration gives tsc the one member we
+ * use without pulling in @types/react-dom.
+ */
+declare module 'react-dom' {
+  import type { ReactNode } from 'react'
+  export function createPortal(children: ReactNode, container: Element | DocumentFragment): ReactNode
+}

--- a/src/ui/client/theme.ts
+++ b/src/ui/client/theme.ts
@@ -11,10 +11,17 @@ export const C = {
   surface: 'var(--dsw-alias-bg-layer-1, #ffffff)',
   surface2: 'var(--dsw-alias-bg-layer-2, #f1f2f5)',
   overlay: 'var(--dsw-alias-bg-overlay, #ffffff)',
-  border: 'var(--dsw-alias-border-l1, #e3e5e9)',
-  borderStrong: 'var(--dsw-alias-border-l2, #c7ccd4)',
   text: 'var(--dsw-alias-label-primary, #1f2329)',
-  muted: 'var(--dsw-alias-label-secondary, #8a919c)',
+  // DSH's label-secondary is extremely faint in the light theme (#cfd3d6 on
+  // white ≈ 1.4:1), which makes hint/secondary text visually merge with the
+  // surface. Derive a readable "muted" from the primary label color instead
+  // (≈72% of near-black in light, ≈72% of near-white in dark), so it stays
+  // legible in both DSH themes while still reading as secondary.
+  muted: 'color-mix(in srgb, var(--dsw-alias-label-primary, #1f2329) 72%, transparent)',
+  // DSH's border-l1 is ~6% black / 9% white — too faint to separate panels.
+  // Use the stronger border-l2 / border-l3 tiers for card and control edges.
+  border: 'var(--dsw-alias-border-l2, #c7ccd4)',
+  borderStrong: 'var(--dsw-alias-border-l3, #9aa1ab)',
   accent: 'var(--dsw-alias-brand-primary, #3b6ef6)',
   danger: 'var(--dsw-alias-state-error-primary, #e5484d)',
   success: 'var(--dsw-alias-state-success-primary, #30a46c)',
@@ -29,8 +36,24 @@ export const PANEL_CSS = `
 @keyframes kb-fade-in { from { opacity: 0; transform: translateY(6px) } to { opacity: 1; transform: none } }
 .kb-spinner { animation: kb-spin 0.9s linear infinite }
 .kb-panel-in { animation: kb-fade-in 0.18s ease-out }
+/* Theme-adaptive interaction fills. DSH's own layer tokens are pure white in
+   the light theme and its interactive-bg-hover is only ~6% alpha, so hovers
+   built on them are nearly invisible. Derive hover/active fills from the
+   inverted label-primary token instead: ~9% black-on-white in light, ~9%
+   white-on-dark in dark — clearly visible in both base themes. Declared on
+   body (portal menus and the sidebar action render outside the panel) and
+   re-scoped to the panel root. */
+body, .kb-panel-in {
+  --kb-hover: color-mix(in srgb, var(--dsw-alias-label-primary, #1f2329) 9%, transparent);
+  --kb-active: color-mix(in srgb, var(--dsw-alias-label-primary, #1f2329) 16%, transparent);
+}
 .kb-row { transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease }
-.kb-row:hover { background: var(--dsw-alias-bg-layer-2, #f1f2f5) }
+.kb-row:hover { background: var(--kb-hover) }
+/* Menu items fill on hover/active; the fill rides a CSS variable referenced from
+   the inline background so the class can override the inline style. */
+.kb-menuitem { transition: background 0.15s ease }
+.kb-menuitem:hover { --kb-mibg: var(--kb-hover) }
+.kb-menuitem:active { --kb-mibg: var(--kb-active) }
 .kb-card { transition: border-color 0.15s ease, background 0.15s ease }
 .kb-card:hover { border-color: var(--dsw-alias-border-l2, #c7ccd4) }
 .kb-iconbtn { transition: color 0.15s ease, background 0.15s ease }
@@ -38,15 +61,43 @@ export const PANEL_CSS = `
 /* Buttons styled with style.button get a hover tint like the shell's own
    buttons. The tint rides a CSS variable referenced from the inline
    background, because inline styles outrank plain class rules: on hover the
-   variable flips and the inline background follows it. */
+   variable flips and the inline background follows it. The .kb-panel-in rule
+   covers every panel button even without the kb-btn class (the class is only
+   required for the settings section, which lives outside the panel). */
 .kb-btn { transition: background 0.15s ease, border-color 0.15s ease }
-.kb-btn:hover { --kb-btn-bg: var(--dsw-alias-interactive-bg-hover, #eceef1) }
+.kb-btn:hover { --kb-btn-bg: var(--kb-hover) }
 .kb-btn:disabled:hover { --kb-btn-bg: var(--dsw-alias-bg-layer-1, #ffffff) }
+.kb-panel-in button:hover { --kb-btn-bg: var(--kb-hover) }
+.kb-panel-in button:disabled:hover { --kb-btn-bg: var(--dsw-alias-bg-layer-1, #ffffff) }
 /* Backgrounds live in classes (not inline) so :hover can override them, the
    same way the shell's Settings trigger styles itself. */
 .kb-sidebar-action { background: transparent }
-.kb-sidebar-action:hover { background: var(--dsw-alias-interactive-bg-hover) }
+.kb-sidebar-action:hover { background: var(--kb-hover) }
+.kb-sidebar-action:active { background: var(--kb-active) }
 .kb-dangerbtn:hover { color: var(--dsw-alias-state-error-primary, #e5484d); background: color-mix(in srgb, var(--dsw-alias-state-error-primary, #e5484d) 10%, transparent) }
+/* Primary (accent-filled) buttons: DSH's brand-primary inverts between themes
+   (near-black in light, near-white in dark) and ships a dedicated hover token,
+   so the hover fill follows that token and stays visible in both. */
+.kb-primary { transition: background 0.15s ease, filter 0.15s ease }
+.kb-primary:hover:not(:disabled) { --kb-primary-bg: var(--dsw-alias-button-primary-hover, #43454a) }
+.kb-primary:active:not(:disabled) { filter: brightness(0.94) }
+.kb-primary:disabled { opacity: 0.5; cursor: not-allowed }
+.kb-danger-primary { transition: background 0.15s ease, filter 0.15s ease }
+.kb-danger-primary:hover:not(:disabled) { --kb-danger-bg: color-mix(in srgb, var(--dsw-alias-state-error-primary, #e5484d) 78%, #000) }
+.kb-danger-primary:active:not(:disabled) { filter: brightness(0.94) }
+.kb-danger-primary:disabled { opacity: 0.5; cursor: not-allowed }
+/* Disabled feedback for every panel button. */
+.kb-panel-in button:disabled { opacity: 0.5; cursor: not-allowed }
+/* Visible focus indicators (DSH's business-primary is a blue that reads in
+   both themes, unlike the inverted brand-primary). */
+.kb-panel-in button:focus-visible, .kb-menuitem:focus-visible, .kb-sidebar-action:focus-visible { outline: 2px solid var(--dsw-alias-state-business-primary, #4176e6); outline-offset: 2px }
+.kb-panel-in input:focus, .kb-panel-in select:focus, .kb-panel-in textarea:focus { box-shadow: 0 0 0 2px color-mix(in srgb, var(--dsw-alias-state-business-primary, #4176e6) 35%, transparent) }
+/* Resize sash: an 8px grab strip whose 2px grip lights up on hover so the
+   draggable edge is discoverable (a 5px transparent sliver was impossible to
+   find/click). z-index keeps it above adjacent scrollbars. */
+.kb-sash { position: relative; z-index: 6 }
+.kb-sash::before { content: ''; position: absolute; top: 0; bottom: 0; left: 50%; transform: translateX(-50%); width: 2px; background: transparent; transition: background 0.15s ease }
+.kb-sash:hover::before { background: color-mix(in srgb, var(--dsw-alias-brand-primary, #3b6ef6) 45%, transparent) }
 .kb-scroll::-webkit-scrollbar { width: 8px; height: 8px }
 .kb-scroll::-webkit-scrollbar-thumb { background: var(--dsw-alias-border-l2, #c7ccd4); border-radius: 999px }
 .kb-scroll::-webkit-scrollbar-track { background: transparent }
@@ -95,6 +146,21 @@ export const style = {
   } as CSSProperties,
   baseName: { fontSize: 13, fontWeight: 600 } as CSSProperties,
   baseMeta: { fontSize: 11, color: C.muted, marginTop: 2 } as CSSProperties,
+  baseSourceRow: {
+    display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '4px 14px',
+    marginTop: 6, padding: '5px 10px', borderRadius: 8,
+    background: 'color-mix(in srgb, var(--dsw-alias-label-primary, #1f2329) 6%, transparent)',
+    fontSize: 11, color: C.muted,
+  } as CSSProperties,
+  baseSourceItem: { display: 'inline-flex', alignItems: 'center', gap: 5, minWidth: 0 } as CSSProperties,
+  baseSourceGlyph: {
+    display: 'inline-flex', alignItems: 'center', flexShrink: 0, color: C.accent,
+  } as CSSProperties,
+  baseSourceText: {
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    fontFamily: "'JetBrains Mono', ui-monospace, 'SF Mono', Consolas, monospace",
+  } as CSSProperties,
+  baseSourceEdit: { marginLeft: 'auto', flexShrink: 0 } as CSSProperties,
   main: { flex: 1, minWidth: 0, overflowY: 'auto', padding: 18, display: 'flex', flexDirection: 'column', gap: 14 } as CSSProperties,
   card: { border: `1px solid ${C.border}`, borderRadius: 12, background: C.surface, padding: 14, position: 'relative' } as CSSProperties,
   cardTitle: { fontSize: 13, fontWeight: 600, margin: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between' } as CSSProperties,
@@ -104,12 +170,16 @@ export const style = {
   } as CSSProperties,
   primary: {
     display: 'inline-flex', alignItems: 'center', gap: 5, border: '1px solid transparent',
-    borderRadius: 8, padding: '6px 14px', background: C.accent, color: '#fff', cursor: 'pointer',
+    borderRadius: 8, padding: '6px 14px', background: `var(--kb-primary-bg, ${C.accent})`,
+    // DSH's brand-primary is near-BLACK in light but near-WHITE in dark; the
+    // foreground token inverts with the theme so the label stays readable on
+    // the accent fill in both modes (white text on white would vanish in dark).
+    color: 'var(--dsw-alias-label-primary-foreground, #fff)', cursor: 'pointer',
     fontSize: 13, fontWeight: 600,
   } as CSSProperties,
   primaryDanger: {
     display: 'inline-flex', alignItems: 'center', gap: 5, border: '1px solid transparent',
-    borderRadius: 8, padding: '6px 14px', background: C.danger, color: '#fff', cursor: 'pointer',
+    borderRadius: 8, padding: '6px 14px', background: `var(--kb-danger-bg, ${C.danger})`, color: 'var(--dsw-alias-label-primary-foreground, #fff)', cursor: 'pointer',
     fontSize: 13, fontWeight: 600,
   } as CSSProperties,
   danger: {
@@ -165,7 +235,8 @@ export const style = {
   empty: { color: C.muted, fontSize: 13, padding: 24, textAlign: 'center' } as CSSProperties,
   error: { color: C.danger, fontSize: 12, background: 'color-mix(in srgb, var(--dsw-alias-state-error-primary, #e5484d) 8%, transparent)', borderRadius: 8, padding: '8px 12px' } as CSSProperties,
   modalBackdrop: {
-    position: 'absolute', inset: 0, zIndex: 20, background: 'rgba(0,0,0,0.32)',
+    position: 'absolute', inset: 0, zIndex: 20, // Less transparent so dialog content stays clearly behind the modal.
+    background: 'rgba(0,0,0,0.58)',
     display: 'flex', alignItems: 'center', justifyContent: 'center',
   } as CSSProperties,
   modal: {
@@ -203,9 +274,14 @@ export const style = {
     display: 'flex', flexDirection: 'column', gap: 8, alignItems: 'center',
   } as CSSProperties,
   toast: {
-    display: 'flex', alignItems: 'center', gap: 8, borderRadius: 999, padding: '8px 16px',
+    display: 'flex', alignItems: 'center', gap: 8, borderRadius: 12, padding: '8px 14px',
     fontSize: 13, fontWeight: 600, background: C.overlay, border: `1px solid ${C.border}`,
-    boxShadow: '0 8px 24px rgba(0,0,0,0.14)', color: C.text,
+    boxShadow: '0 8px 24px rgba(0,0,0,0.14)', color: C.text, maxWidth: 'min(90vw, 560px)',
+  } as CSSProperties,
+  toastClose: {
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+    width: 20, height: 20, border: 'none', borderRadius: 999, background: 'transparent',
+    color: C.muted, cursor: 'pointer', padding: 0, marginLeft: 2,
   } as CSSProperties,
   fileRow: {
     display: 'flex', alignItems: 'center', gap: 8, border: `1px solid ${C.border}`,
@@ -214,10 +290,13 @@ export const style = {
   spinner: { display: 'inline-block', width: 14, height: 14, borderRadius: '50%', border: '2px solid currentColor', borderTopColor: 'transparent' } as CSSProperties,
   menu: {
     position: 'absolute', zIndex: 30, minWidth: 180, borderRadius: 10, padding: 4,
-    background: C.overlay, border: `1px solid ${C.border}`, boxShadow: '0 10px 32px rgba(0,0,0,0.18)',
+    // Opaque overlay surface (never translucent) with the stronger border tier
+    // so the popover separates from the panel in both themes.
+    background: C.overlay, border: `1px solid ${C.borderStrong}`, boxShadow: '0 10px 32px rgba(0,0,0,0.22)',
+    color: C.text,
   } as CSSProperties,
   menuItem: {
-    display: 'flex', alignItems: 'center', gap: 8, width: '100%', border: 'none', background: 'transparent',
+    display: 'flex', alignItems: 'center', gap: 8, width: '100%', border: 'none', background: 'var(--kb-mibg, transparent)',
     borderRadius: 7, padding: '7px 10px', fontSize: 13, color: C.text, cursor: 'pointer', textAlign: 'left',
   } as CSSProperties,
   menuItemDanger: { color: C.danger } as CSSProperties,
@@ -233,7 +312,10 @@ export const style = {
   } as CSSProperties,
   switchOn: { background: C.accent } as CSSProperties,
   switchKnob: {
-    position: 'absolute', top: 2, left: 2, width: 16, height: 16, borderRadius: '50%', background: '#fff',
+    position: 'absolute', top: 2, left: 2, width: 16, height: 16, borderRadius: '50%',
+    // Contrasts with the accent track in both themes (near-black knob on the
+    // near-white accent in dark mode, near-white knob on dark accent in light).
+    background: 'var(--dsw-alias-label-primary-foreground, #fff)',
     transition: 'transform 0.15s',
   } as CSSProperties,
   accordionHeader: {
@@ -267,9 +349,14 @@ export const style = {
     cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
     color: '#fff', padding: 0, flexShrink: 0, fontSize: 11, lineHeight: 1,
   } as CSSProperties,
-  checkboxOn: { background: C.accent, borderColor: C.accent } as CSSProperties,
+  checkboxOn: {
+    background: C.accent, borderColor: C.accent,
+    color: 'var(--dsw-alias-label-primary-foreground, #fff)',
+  } as CSSProperties,
   sidePanelScrim: {
-    position: 'absolute', inset: 0, zIndex: 30, background: 'rgba(0,0,0,0.28)',
+    // Less transparent scrim so the drawer clearly separates from the
+    // panel behind it (nothing reads through).
+    position: 'absolute', inset: 0, zIndex: 30, background: 'rgba(0,0,0,0.58)',
     display: 'flex', justifyContent: 'flex-end',
   } as CSSProperties,
   sidePanel: {
@@ -302,15 +389,27 @@ export function formatSize(charCount: number): string {
   return `${(charCount / (1024 * 1024)).toFixed(2)} MB`
 }
 
-/** Compact relative time, Cherry Studio style (刚刚 / N 分钟前 / N 小时前…). */
-export function formatRelativeTime(timestamp: number, now: number = Date.now()): string {
+/**
+ * Compact relative time, locale-aware via the bound translate (the old
+ * implementation hardcoded Chinese “刚刚 / N 分钟前…” which leaked into the
+ * English UI). now is only overridable for tests.
+ */
+export function formatRelativeTime(
+  timestamp: number,
+  // Optional so the previous one-arg call keeps compiling on `main` until
+  // KnowledgeSection adopts the locale-aware signature in the feature branch.
+  // Narrow key union keeps it callable with the bound Translate
+  // ((key: KnowledgeKey) => string) while staying decoupled from locales.
+  t?: (key: 'timeJustNow' | 'timeMinutes' | 'timeHours' | 'timeDays') => string,
+  now: number = Date.now(),
+): string {
   const diff = Math.max(0, now - timestamp)
   const minutes = Math.floor(diff / 60000)
-  if (minutes < 1) return '刚刚'
-  if (minutes < 60) return `${minutes} 分钟前`
+  if (minutes < 1) return t !== undefined ? t('timeJustNow') : '刚刚'
+  if (minutes < 60) return t !== undefined ? t('timeMinutes').replace('{n}', String(minutes)) : `${minutes} 分钟前`
   const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours} 小时前`
+  if (hours < 24) return t !== undefined ? t('timeHours').replace('{n}', String(hours)) : `${hours} 小时前`
   const days = Math.floor(hours / 24)
-  if (days < 30) return `${days} 天前`
+  if (days < 30) return t !== undefined ? t('timeDays').replace('{n}', String(days)) : `${days} 天前`
   return new Date(timestamp).toLocaleDateString()
 }


### PR DESCRIPTION
## Summary
Theme + interaction fixes for the client: theme-adaptive tokens, a portal-based `PopoverMenu` that actually fires its actions, toast dismissal, and localized/Ollama-aware settings.

## Changes
- `theme.ts` — `kb-primary`/`kb-danger-primary` hover/active tokens, theme-adaptive `muted`/`border`/focus/sash/toast styling; `formatRelativeTime` takes an **optional** locale translate (falls back to the previous labels), so this merges before the feature branch adopts it.
- `popover.tsx` — menu renders in a body-level portal and tracks its own ref, so clicks on items are no longer treated as outside-clicks (fixes dead menu actions); auto-flips above/below the trigger, closes on scroll/resize.
- `react-dom.d.ts` — `createPortal` type shim.
- `dialogs.tsx` — toast dismiss button + text selection, `kb-primary` classes, restore dialog auto-fills the Ollama URL and uses localized provider labels.
- `rag-config.tsx` — MinerU/caption placeholders localized, `embeddingBaseUrl` auto-fills `http://127.0.0.1:11434` for Ollama, `kb-primary` on save.
- `LocalModelsSection.tsx` — pulling/refreshing an Ollama server persists it as the global embedding default; localized cache-dir messages.

## Merge order
**Depends on #`feat/locales`** (uses `mineruOption`, `cacheDir*`, … keys). Merge after `feat/locales`, before `feat/local-path-import`.

## Testing
- `pnpm run typecheck` — clean against `main` + `feat/locales`.
