### PR TITLE
feat: integrate community knowledge and UI improvements (#10–#13)

### DIFF
--- a/docs/superpowers/specs/2026-09-02-pr-10-13-integration-design.md
+++ b/docs/superpowers/specs/2026-09-02-pr-10-13-integration-design.md
@@ -1,0 +1,133 @@
+# PR #10–#13 Integration Design
+
+## Objective
+
+Integrate the useful work from community PRs #10–#13 without placing known
+behavioral or data-integrity defects on `main`. Preserve the contributor's
+original commits and authorship, apply maintainer fixes on an isolated branch,
+and merge only after the combined result passes the repository's full release
+quality gates.
+
+This integration does not change the package version, create a tag, publish to
+npm, merge into `main`, or push to GitHub without a separate maintainer action.
+
+## Branch and commit strategy
+
+- Work only on `integration/pr-10-13`, created from clean `v0.3.8` commit
+  `ac952a1`.
+- Cherry-pick the contributor commits in dependency order: #10, #11, #13,
+  then #12.
+- Keep the contributor commits intact so Git records their original author.
+- Add maintainer fixes and tests as separate, reviewable commits.
+- Do not rewrite or close the contributor's new PRs during local integration.
+
+## Accepted contribution scope
+
+### PR #10 — Ollama empty-URL fallback
+
+Keep the server-side fallback from an empty Ollama embedding URL to
+`http://127.0.0.1:11434`. Empty OpenAI-compatible URLs must continue to fail.
+Add a regression test that observes the requested URL rather than relying on a
+live Ollama server.
+
+### PR #11 — locale additions
+
+Keep the additive Chinese and English locale keys. Correct awkward English
+copy, especially the cache-migration message, and ensure labels describe
+source items accurately when the count includes both folders and files.
+
+### PR #13 — theme and interaction improvements
+
+Keep the theme tokens, readable secondary text, focus feedback, portal menu,
+localized placeholders, and dismissible toasts, subject to these constraints:
+
+- Refreshing or pulling an Ollama model must not silently change the global
+  embedding provider, URL, or selected model. Configuration changes remain in
+  explicit configuration controls.
+- The toast close button must be connected to state removal in the same
+  integrated result.
+- The top-level portal menu must remain within the viewport. Nested menus must
+  open beside their parent and flip horizontally when necessary rather than
+  covering following parent-menu rows.
+- Menu actions, outside-click dismissal, and submenu placement should be
+  expressed through independently testable helpers where practical.
+
+### PR #12 — local-path import and source tracking
+
+Keep server-side file/directory path import, unique raw-copy storage, base
+source summaries, source edit UI, orphan reconciliation, and the contributor's
+two regression tests. Tighten the source-edit contract as follows.
+
+#### Source identity
+
+`BaseSourceInfo` carries the top-level source document ID. The UI renders an
+edit action only for path-backed file and directory sources, and associates
+the action with the selected source row. The source-path endpoint accepts both
+`sourceId` and `path`.
+
+The service rejects a target that does not exist, belongs to another base, is
+nested rather than top-level, or is not a file/directory source. Updating one
+source must never update sibling roots. URL and manual-text sources are not
+offered a path edit.
+
+#### Path and parser correctness
+
+Path-import and source-edit inputs must be absolute existing paths. A file
+source must point to a supported file type. Repointing a file updates its
+stored `fileName` to the new basename and clears stale MIME metadata so reindex
+selects the parser from the new source rather than the old extension. A
+directory source may only point to a directory.
+
+#### Failure-safe raw replacement
+
+Re-reading a tracked file writes the candidate bytes to a fresh raw path. The
+old raw copy remains referenced until new chunks and the updated document have
+been committed. On failure, delete only the candidate copy and retain the old
+document/raw relationship. After successful commit, delete the superseded raw
+copy; a cleanup failure is logged and left for orphan reconciliation.
+
+#### Import result visibility
+
+Directory path import must not discard per-file errors. Return the error list
+to the client and surface a warning when the import is partial. Use the
+existing long-operation HTTP budget so a directory import is not cut off by
+the generic 60-second panel timeout. A new background-job architecture is out
+of scope for this integration.
+
+## Compatibility and boundaries
+
+- No database migration or re-embedding is required.
+- Existing v0.3.8 documents without `sourcePath` keep their current rebuild
+  behavior.
+- The current raw-cache root remains dedicated to knowledge source copies.
+- No changes to chunking, reranking, retrieval ranking, OCR policy, version
+  metadata, release tags, or npm publication are included.
+- No implicit configuration mutation is introduced by model browsing.
+
+## Verification
+
+Add or retain automated coverage for:
+
+- empty Ollama URL fallback and empty OpenAI URL rejection;
+- source edit targets exactly one of multiple top-level files/directories;
+- cross-base, nested, missing, relative, and type-mismatched source targets;
+- cross-extension file repoint uses the new parser identity;
+- failed reindex retains the previous raw reference and removes the candidate;
+- duplicate directory-relative filenames keep independent raw copies;
+- partial path imports return their errors;
+- toast dismissal and deterministic menu placement helpers;
+- no model-refresh or model-pull path silently persists embedding config.
+
+Before handoff, run:
+
+- `npm run typecheck`
+- full Vitest suite
+- `npm run benchmark`
+- `npm run build`
+- `npm run verify:release`
+- `npm run verify:package`
+- relevant packed smoke tests when the combined source changes packaging or
+  runtime boot behavior
+
+The integration is ready for maintainer review only when the working tree is
+clean and every required local gate passes.

--- a/src/knowledge/embed.ts
+++ b/src/knowledge/embed.ts
@@ -87,9 +87,13 @@ export async function embedTexts(
     // waiting immediately while the isolated worker finishes its current job.
     return await withAbortSignal(embedLocal(model.trim() === '' ? DEFAULT_LOCAL_MODEL : model, texts), signal)
   }
-  if (baseUrl.trim() === '') throw new Error('embedding base URL is empty')
   if (model.trim() === '') throw new Error('embedding model is empty')
-  if (provider === 'openai') return embedOpenAI(baseUrl, model, apiKey, texts, signal)
+  if (provider === 'openai') {
+    if (baseUrl.trim() === '') throw new Error('embedding base URL is empty')
+    return embedOpenAI(baseUrl, model, apiKey, texts, signal)
+  }
+  // Ollama defaults an empty base URL to the well-known local endpoint, so a
+  // base with an unset URL still embeds against http://127.0.0.1:11434.
   if (provider === 'ollama') return embedOllama(baseUrl, model, apiKey, texts, signal)
   throw new Error(`unknown embedding provider ${String(provider)}`)
 }
@@ -503,7 +507,7 @@ async function embedOllama(
   texts: readonly string[],
   signal?: AbortSignal,
 ): Promise<number[][]> {
-  const base = trimBase(baseUrl)
+  const base = trimBase(baseUrl.trim() === '' ? 'http://127.0.0.1:11434' : baseUrl)
   // Modern Ollama: POST /api/embed { model, input: [..] } -> { embeddings: [[..]] }
   const response = await httpFetch(`${base}/api/embed`, {
     method: 'POST',

--- a/src/knowledge/http.ts
+++ b/src/knowledge/http.ts
@@ -312,7 +312,11 @@ async function route(
         return service.importFromPath(baseId, typeof body.path === 'string' ? body.path : '')
       }
       if (segments[2] === 'source-path' && method === 'POST') {
-        return service.setBaseSourcePath(baseId, typeof body.path === 'string' ? body.path : '')
+        return service.setBaseSourcePath(
+          baseId,
+          typeof body.sourceId === 'string' ? body.sourceId : '',
+          typeof body.path === 'string' ? body.path : '',
+        )
       }
       if (segments[2] === 'directories' && method === 'POST') {
         return service.createDirectory(

--- a/src/knowledge/http.ts
+++ b/src/knowledge/http.ts
@@ -308,6 +308,12 @@ async function route(
       if (segments[2] === 'import-directory-tree' && method === 'POST') {
         return service.importDirectoryTree(baseId, typeof body.path === 'string' ? body.path : '')
       }
+      if (segments[2] === 'import-path' && method === 'POST') {
+        return service.importFromPath(baseId, typeof body.path === 'string' ? body.path : '')
+      }
+      if (segments[2] === 'source-path' && method === 'POST') {
+        return service.setBaseSourcePath(baseId, typeof body.path === 'string' ? body.path : '')
+      }
       if (segments[2] === 'directories' && method === 'POST') {
         return service.createDirectory(
           baseId,

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -1213,9 +1213,16 @@ export class KnowledgeService extends Service {
    * validating that it exists first. Directories reuse the tree import, which
    * records `sourcePath` on every container so reindex rescans the disk.
    */
-  async importFromPath(baseId: string, path: string): Promise<{ kind: 'directory' | 'file'; imported: number }> {
+  async importFromPath(baseId: string, path: string): Promise<{
+    kind: 'directory' | 'file'
+    imported: number
+    errors: Array<{ file: string; error: string }>
+  }> {
+    const store = this.requireStore()
+    if (store.getBase(baseId) === undefined) throw new Error(`knowledge base not found: ${baseId}`)
     const trimmed = path.trim()
     if (trimmed.length === 0) throw new Error('path is required')
+    if (!isAbsolute(trimmed)) throw new Error(`path must be absolute: ${trimmed}`)
     let st
     try {
       st = await stat(trimmed)
@@ -1224,51 +1231,60 @@ export class KnowledgeService extends Service {
     }
     if (st.isDirectory()) {
       const result = await this.importDirectoryTree(baseId, trimmed)
-      return { kind: 'directory', imported: result.imported }
+      return { kind: 'directory', imported: result.imported, errors: result.errors }
     }
     if (st.isFile()) {
       await this.importFileFromPath(baseId, trimmed)
-      return { kind: 'file', imported: 1 }
+      return { kind: 'file', imported: 1, errors: [] }
     }
     throw new Error(`not a file or directory: ${trimmed}`)
   }
 
   /**
-   * Repoint a base's source. The target set is chosen by the KIND of the
-   * passed path, not by whichever roots happen to exist: an existing
-   * DIRECTORY repoints every top-level directory container, an existing FILE
-   * repoints every top-level file document. This lets a mixed base — several
-   * imported directory roots plus a couple of single-file imports — repoint
-   * just the file source even when directory roots are present (previously the
-   * presence of any directory root made the file repoint fail with
-   * "not a directory"). Used by the pencil button next to the base's source line.
+   * Repoint exactly one top-level file or directory source. Source identity is
+   * explicit: a base may contain several independent roots of the same kind,
+   * and editing one must never redirect its siblings.
    */
-  async setBaseSourcePath(baseId: string, path: string): Promise<{ set: number }> {
+  async setBaseSourcePath(baseId: string, sourceId: string, path: string): Promise<{ set: number }> {
     const store = this.requireStore()
     if (store.getBase(baseId) === undefined) throw new Error(`knowledge base not found: ${baseId}`)
+    const source = store.getDocument(sourceId)
+    if (source === undefined) throw new Error(`source document not found: ${sourceId}`)
+    if (source.baseId !== baseId) throw new Error(`source ${sourceId} does not belong to knowledge base ${baseId}`)
+    if (source.parentDirectoryId !== undefined) throw new Error('source path can only be changed for a top-level source')
+    if (source.sourceType !== 'file' && source.sourceType !== 'directory') {
+      throw new Error('source path can only be changed for a file or directory source')
+    }
     const trimmed = path.trim()
     if (trimmed.length === 0) throw new Error('path is required')
+    if (!isAbsolute(trimmed)) throw new Error(`path must be absolute: ${trimmed}`)
     let st
     try {
       st = await stat(trimmed)
     } catch {
       throw new Error(`path not found: ${trimmed}`)
     }
-    const roots = store.listDocuments(baseId).filter(doc => doc.parentDirectoryId === undefined)
-    let targets: KnowledgeDocument[]
-    if (st.isDirectory()) {
-      targets = roots.filter(doc => doc.sourceType === 'directory')
-      if (targets.length === 0) throw new Error('base has no directory source to repoint')
-    } else if (st.isFile()) {
-      targets = roots.filter(doc => doc.sourceType === 'file')
-      if (targets.length === 0) throw new Error('base has no file source to repoint')
+    if (source.sourceType === 'directory') {
+      if (!st.isDirectory()) throw new Error('a directory source must be repointed to a directory')
+      await store.putDocument({ ...source, sourcePath: trimmed, updatedAt: Date.now() })
     } else {
-      throw new Error(`not a file or directory: ${trimmed}`)
+      if (!st.isFile()) throw new Error('a file source must be repointed to a file')
+      const nextFileName = basename(trimmed)
+      if (!SUPPORTED_DOCUMENT_EXTENSION_SET.has(extensionOf(nextFileName))) {
+        throw new Error(`Unsupported knowledge file type: ${nextFileName}`)
+      }
+      // Drop stale MIME metadata so parser dispatch follows the new source's
+      // extension. Preserve the user-facing title, which may have been renamed.
+      const { mimeType: _staleMimeType, ...withoutMimeType } = source
+      await store.putDocument({
+        ...withoutMimeType,
+        sourcePath: trimmed,
+        fileName: nextFileName,
+        updatedAt: Date.now(),
+      })
     }
-    for (const doc of targets) {
-      await store.putDocument({ ...doc, sourcePath: trimmed, updatedAt: Date.now() })
-    }
-    return { set: targets.length }
+    await this.touchBase(baseId)
+    return { set: 1 }
   }
 
   async addUrlDocument(request: ImportUrlRequest): Promise<KnowledgeDocument> {
@@ -1448,40 +1464,65 @@ export class KnowledgeService extends Service {
     // Fall back to the persisted text (then to reconstructed chunks) when the
     // file is gone or unreadable — a reindex must never wipe vectors for a
     // source that cannot be rebuilt.
-    const { text, rawFilePath: nextRawFilePath } = await this.sourceTextOf(document)
-    const config = this.getConfigFor(document.baseId)
-    // Mark the document incomplete so a crash mid-reindex is resumed on the
-    // next start (buildChunks persists each embedded batch; hash reuse makes
-    // the resume re-embed only what never landed).
-    await store.putDocument({ ...document, incomplete: true, updatedAt: Date.now() })
-    const { chunks, embeddingError, embeddingErrorCode } = await this.buildChunks(document.baseId, document.id, document.title, text, config, undefined, batch => store.putChunkBatch(batch))
-    const { embeddingError: _staleError, errorCode: _staleCode, incomplete: _staleIncomplete, contentHash: _staleHash, ...rest } = document
-    const next: KnowledgeDocument = {
-      ...rest,
-      // A refreshed raw copy (e.g. sourceTextOf re-read a repointed sourcePath)
-      // must win over the stale stored path.
-      ...(nextRawFilePath !== undefined ? { rawFilePath: nextRawFilePath } : {}),
-      rawText: text,
-      contentHash: sha256(text),
-      charCount: text.length,
-      tokenCount: estimateTokens(text),
-      chunkCount: chunks.length,
-      ...(embeddingError !== undefined
-        ? { embeddingError, ...(embeddingErrorCode !== undefined ? { errorCode: embeddingErrorCode } : {}) }
-        : {}),
-      updatedAt: Date.now(),
+    const rebuilt = await this.sourceTextOf(document)
+    const discardCandidate = async (): Promise<void> => {
+      if (rebuilt.candidateRawFilePath === undefined) return
+      try {
+        await store.raw?.delete(rebuilt.candidateRawFilePath)
+      } catch (error) {
+        this.ctx.logger.warn(`knowledge: failed to discard uncommitted raw source ${rebuilt.candidateRawFilePath}: ${error instanceof Error ? error.message : String(error)}`)
+      }
     }
-    // putChunks overwrites the doc's chunk bundle in one write (legacy per-chunk
-    // rows, if any, stay hidden because a bundle record is authoritative).
-    // A delete that landed mid-reindex must not resurrect rows or chunks
-    // (Cherry's deleting-guard).
-    if (store.getDocument(document.id) === undefined || store.getBase(document.baseId) === undefined) {
-      return document
+    let candidateCommitted = false
+    try {
+      const config = this.getConfigFor(document.baseId)
+      // Mark the document incomplete so a crash mid-reindex is resumed on the
+      // next start (buildChunks persists each embedded batch; hash reuse makes
+      // the resume re-embed only what never landed). The document continues to
+      // reference the previous raw copy until the complete replacement commits.
+      await store.putDocument({ ...document, incomplete: true, updatedAt: Date.now() })
+      const { chunks, embeddingError, embeddingErrorCode } = await this.buildChunks(document.baseId, document.id, document.title, rebuilt.text, config, undefined, batch => store.putChunkBatch(batch))
+      const { embeddingError: _staleError, errorCode: _staleCode, incomplete: _staleIncomplete, contentHash: _staleHash, ...rest } = document
+      const next: KnowledgeDocument = {
+        ...rest,
+        ...(rebuilt.rawFilePath !== undefined ? { rawFilePath: rebuilt.rawFilePath } : {}),
+        rawText: rebuilt.text,
+        contentHash: sha256(rebuilt.text),
+        charCount: rebuilt.text.length,
+        tokenCount: estimateTokens(rebuilt.text),
+        chunkCount: chunks.length,
+        ...(embeddingError !== undefined
+          ? { embeddingError, ...(embeddingErrorCode !== undefined ? { errorCode: embeddingErrorCode } : {}) }
+          : {}),
+        updatedAt: Date.now(),
+      }
+      // putChunks overwrites the doc's chunk bundle in one write (legacy
+      // per-chunk rows, if any, stay hidden because a bundle record is
+      // authoritative). A delete that landed mid-reindex must not resurrect
+      // rows, chunks, or the candidate raw source.
+      if (store.getDocument(document.id) === undefined || store.getBase(document.baseId) === undefined) {
+        await discardCandidate()
+        return document
+      }
+      await store.putChunks(chunks)
+      await store.putDocument(next)
+      candidateCommitted = true
+
+      if (rebuilt.previousRawFilePath !== undefined && rebuilt.previousRawFilePath !== rebuilt.rawFilePath) {
+        try {
+          await store.raw?.delete(rebuilt.previousRawFilePath)
+        } catch (error) {
+          // The new document already points at the committed candidate. Leave
+          // an undeleted predecessor for startup orphan reconciliation.
+          this.ctx.logger.warn(`knowledge: failed to remove superseded raw source ${rebuilt.previousRawFilePath}: ${error instanceof Error ? error.message : String(error)}`)
+        }
+      }
+      await this.touchBase(document.baseId)
+      return next
+    } catch (error) {
+      if (!candidateCommitted) await discardCandidate()
+      throw error
     }
-    await store.putChunks(chunks)
-    await store.putDocument(next)
-    await this.touchBase(document.baseId)
-    return next
   }
 
   /** Rebuild source text of a document. A path-imported single file (sourcePath)
@@ -1489,7 +1530,12 @@ export class KnowledgeService extends Service {
    *  are picked up, refreshing the persisted raw copy; otherwise the raw copy,
    *  then persisted text, then reconstructed chunks are used. Returns the rebuilt
    *  text and, when the raw copy was refreshed, its new base-relative path. */
-  private async sourceTextOf(document: KnowledgeDocument): Promise<{ text: string; rawFilePath?: string }> {
+  private async sourceTextOf(document: KnowledgeDocument): Promise<{
+    text: string
+    rawFilePath?: string
+    candidateRawFilePath?: string
+    previousRawFilePath?: string
+  }> {
     const store = this.requireStore()
     // A single-file path import tracks its live source on disk. Reindex re-reads
     // that path so edits and a repointed source (setBaseSourcePath) are actually
@@ -1499,15 +1545,21 @@ export class KnowledgeService extends Service {
       try {
         const buffer = await readFile(document.sourcePath)
         if (buffer.byteLength > 0) {
-          const text = await parseDocumentBuffer(buffer, document.fileName ?? document.title, document.mimeType)
+          const fileName = basename(document.sourcePath)
+          // A repointed source may use a different extension. Dispatch from
+          // the live source identity rather than stale fileName/MIME metadata.
+          const text = await parseDocumentBuffer(buffer, fileName)
           if (text.trim().length > 0) {
             if (store.raw !== undefined) {
-              const fileName = document.fileName ?? document.title
-              const nextRaw = await store.raw.write(document.baseId, document.id, safeRawExtension(fileName), buffer)
-              if (nextRaw !== document.rawFilePath && document.rawFilePath !== undefined) {
-                await store.raw.delete(document.rawFilePath)
+              // Always stage to a fresh path. The caller switches the document
+              // reference only after chunks and metadata commit successfully.
+              const nextRaw = await store.raw.write(document.baseId, crypto.randomUUID(), safeRawExtension(fileName), buffer)
+              return {
+                text,
+                rawFilePath: nextRaw,
+                candidateRawFilePath: nextRaw,
+                ...(document.rawFilePath !== undefined ? { previousRawFilePath: document.rawFilePath } : {}),
               }
-              return { text, rawFilePath: nextRaw }
             }
             return { text }
           }
@@ -3273,7 +3325,6 @@ function effectiveMode(requested: SearchMode, ranked: readonly RankedHit[]): Sea
  *  root, so only `parentDirectoryId === undefined` items are listed. */
 function baseSourceLines(documents: KnowledgeDocument[]): BaseSourceInfo[] {
   const MAX = 4
-  const seen = new Set<string>()
   const lines: BaseSourceInfo[] = []
   for (const doc of documents) {
     if (doc.parentDirectoryId !== undefined) continue
@@ -3292,10 +3343,12 @@ function baseSourceLines(documents: KnowledgeDocument[]): BaseSourceInfo[] {
       kind = 'text'
       text = 'node'
     }
-    const key = `${kind}:${text}`
-    if (seen.has(key)) continue
-    seen.add(key)
-    lines.push({ kind, text })
+    lines.push({
+      sourceId: doc.id,
+      kind,
+      text,
+      ...(doc.sourcePath !== undefined ? { sourcePath: doc.sourcePath } : {}),
+    })
     if (lines.length >= MAX) break
   }
   return lines

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -1234,10 +1234,14 @@ export class KnowledgeService extends Service {
   }
 
   /**
-   * Repoint a base's source: set `sourcePath` on every top-level directory
-   * container (path must be an existing directory), or on every top-level file
-   * document (path must be an existing file) when the base has no directory
-   * root. Used by the pencil button next to the base's source line.
+   * Repoint a base's source. The target set is chosen by the KIND of the
+   * passed path, not by whichever roots happen to exist: an existing
+   * DIRECTORY repoints every top-level directory container, an existing FILE
+   * repoints every top-level file document. This lets a mixed base — several
+   * imported directory roots plus a couple of single-file imports — repoint
+   * just the file source even when directory roots are present (previously the
+   * presence of any directory root made the file repoint fail with
+   * "not a directory"). Used by the pencil button next to the base's source line.
    */
   async setBaseSourcePath(baseId: string, path: string): Promise<{ set: number }> {
     const store = this.requireStore()
@@ -1251,17 +1255,15 @@ export class KnowledgeService extends Service {
       throw new Error(`path not found: ${trimmed}`)
     }
     const roots = store.listDocuments(baseId).filter(doc => doc.parentDirectoryId === undefined)
-    const dirRoots = roots.filter(doc => doc.sourceType === 'directory')
-    const fileRoots = roots.filter(doc => doc.sourceType === 'file')
     let targets: KnowledgeDocument[]
-    if (dirRoots.length > 0) {
-      if (!st.isDirectory()) throw new Error(`not a directory: ${trimmed}`)
-      targets = dirRoots
-    } else if (fileRoots.length > 0) {
-      if (!st.isFile()) throw new Error(`not a file: ${trimmed}`)
-      targets = fileRoots
+    if (st.isDirectory()) {
+      targets = roots.filter(doc => doc.sourceType === 'directory')
+      if (targets.length === 0) throw new Error('base has no directory source to repoint')
+    } else if (st.isFile()) {
+      targets = roots.filter(doc => doc.sourceType === 'file')
+      if (targets.length === 0) throw new Error('base has no file source to repoint')
     } else {
-      throw new Error('base has no directory or file source to repoint')
+      throw new Error(`not a file or directory: ${trimmed}`)
     }
     for (const doc of targets) {
       await store.putDocument({ ...doc, sourcePath: trimmed, updatedAt: Date.now() })

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -58,6 +58,7 @@ import type {
   AddFilesResult,
   AddTextDocumentRequest,
   BaseConfig,
+  BaseSourceInfo,
   BaseStats,
   BaseSummary,
   CreateBaseRequest,
@@ -664,16 +665,20 @@ export class KnowledgeService extends Service {
       const chunkCount = documents.reduce((sum, doc) => sum + doc.chunkCount, 0)
       const charCount = documents.reduce((sum, doc) => sum + doc.charCount, 0)
       const tokenCount = documents.reduce((sum, doc) => sum + (doc.tokenCount ?? 0), 0)
+      const storedDocCount = documents.reduce((sum, doc) => sum + (doc.rawFilePath !== undefined ? 1 : 0), 0)
+      const sourceInfo = baseSourceLines(documents)
       return {
         id: base.id,
         name: base.name,
         description: base.description,
         ...(base.group !== undefined ? { group: base.group } : {}),
         documentCount: documents.length,
+        storedDocCount,
         chunkCount,
         charCount,
         tokenCount,
         ...(base.config !== undefined ? { config: base.config } : {}),
+        ...(sourceInfo.length > 0 ? { sourceInfo } : {}),
         createdAt: base.createdAt,
         updatedAt: base.updatedAt,
       }
@@ -1029,20 +1034,29 @@ export class KnowledgeService extends Service {
           continue
         }
         // Cherry's prepare-root: persist a raw copy (base-relative path) so
-        // the base stays rebuildable if the source disk changes.
+        // the base stays rebuildable if the source disk changes. The stored
+        // path is derived from a fresh uuid (not the source file name) so two
+        // roots containing the same relative path can never collide.
         let rawFilePath: string | undefined
         const store = this.requireStore()
         if (store.raw !== undefined) {
-          rawFilePath = await store.raw.writeRel(job.baseId, basename(file), buffer)
+          rawFilePath = await store.raw.write(job.baseId, crypto.randomUUID(), safeRawExtension(basename(file)), buffer)
         }
-        await this.ingestDocument({
-          baseId: job.baseId,
-          title: basename(file),
-          sourceType: 'file',
-          fileName: basename(file),
-          rawFilePath,
-          text,
-        })
+        try {
+          await this.ingestDocument({
+            baseId: job.baseId,
+            title: basename(file),
+            sourceType: 'file',
+            fileName: basename(file),
+            rawFilePath,
+            text,
+          })
+        } catch (error) {
+          // A rejected item (e.g. duplicate content) must not leave an
+          // orphaned raw copy behind.
+          if (rawFilePath !== undefined) await store.raw?.delete(rawFilePath)
+          throw error
+        }
         job.imported += 1
       } catch (error) {
         job.errors.push({ file, error: error instanceof Error ? error.message : String(error) })
@@ -1120,22 +1134,30 @@ export class KnowledgeService extends Service {
             const text = await parseDocumentBuffer(buffer, basename(full))
             if (text.trim().length === 0) continue
             // Cherry's prepare-root: the base owns a stable copy of every
-            // imported file under raw/ (tree-relative path), so a later
-            // reindex rebuilds from the base even if the source disk changes.
+            // imported file under raw/, so a later reindex rebuilds from the
+            // base even if the source disk changes. The stored path is a fresh
+            // uuid (not the tree-relative path) so two roots that share a
+            // relative path never collide in raw storage.
             let rawFilePath: string | undefined
             if (store.raw !== undefined) {
-              const relPath = relative(path, full).replace(/\\/g, '/')
-              rawFilePath = await store.raw.writeRel(baseId, relPath, buffer)
+              rawFilePath = await store.raw.write(baseId, crypto.randomUUID(), safeRawExtension(basename(full)), buffer)
             }
-            await this.ingestDocument({
-              baseId,
-              title: basename(full),
-              sourceType: 'file',
-              fileName: basename(full),
-              parentDirectoryId: parentId,
-              rawFilePath,
-              text,
-            })
+            try {
+              await this.ingestDocument({
+                baseId,
+                title: basename(full),
+                sourceType: 'file',
+                fileName: basename(full),
+                parentDirectoryId: parentId,
+                rawFilePath,
+                text,
+              })
+            } catch (error) {
+              // A rejected item (e.g. duplicate content) must not leave an
+              // orphaned raw copy behind.
+              if (rawFilePath !== undefined) await store.raw?.delete(rawFilePath)
+              throw error
+            }
             imported += 1
           } catch (error) {
             errors.push({ file: full, error: error instanceof Error ? error.message : String(error) })
@@ -1146,6 +1168,105 @@ export class KnowledgeService extends Service {
 
     await walk(path, rootId, 0)
     return { imported, directories, errors }
+  }
+
+  /** Import a single local file by its absolute path (server-side). */
+  async importFileFromPath(baseId: string, filePath: string): Promise<{ imported: boolean; title: string }> {
+    const store = this.requireStore()
+    if (store.getBase(baseId) === undefined) throw new Error(`knowledge base not found: ${baseId}`)
+    const name = basename(filePath)
+    if (!SUPPORTED_DOCUMENT_EXTENSION_SET.has(extensionOf(name))) {
+      throw new Error(`Unsupported knowledge file type: ${name}`)
+    }
+    const buffer = await readFile(filePath)
+    const text = await parseDocumentBuffer(buffer, name)
+    if (text.trim().length === 0) throw new Error(`file is empty or unreadable: ${filePath}`)
+    // Persist a stable raw copy (Cherry's "import means copy") so the base
+    // stays rebuildable even if the source file changes or disappears. The
+    // stored path is a fresh uuid so it never collides with another import of
+    // the same file name.
+    let rawFilePath: string | undefined
+    if (store.raw !== undefined) {
+      rawFilePath = await store.raw.write(baseId, crypto.randomUUID(), safeRawExtension(name), buffer)
+    }
+    try {
+      await this.ingestDocument({
+        baseId,
+        title: name,
+        sourceType: 'file',
+        fileName: name,
+        rawFilePath,
+        sourcePath: filePath,
+        text,
+      })
+    } catch (error) {
+      // A rejected item (e.g. duplicate content) must not leave an orphaned
+      // raw copy behind.
+      if (rawFilePath !== undefined) await store.raw?.delete(rawFilePath)
+      throw error
+    }
+    return { imported: true, title: name }
+  }
+
+  /**
+   * Import a local path (directory tree or single file) by its absolute path,
+   * validating that it exists first. Directories reuse the tree import, which
+   * records `sourcePath` on every container so reindex rescans the disk.
+   */
+  async importFromPath(baseId: string, path: string): Promise<{ kind: 'directory' | 'file'; imported: number }> {
+    const trimmed = path.trim()
+    if (trimmed.length === 0) throw new Error('path is required')
+    let st
+    try {
+      st = await stat(trimmed)
+    } catch {
+      throw new Error(`path not found: ${trimmed}`)
+    }
+    if (st.isDirectory()) {
+      const result = await this.importDirectoryTree(baseId, trimmed)
+      return { kind: 'directory', imported: result.imported }
+    }
+    if (st.isFile()) {
+      await this.importFileFromPath(baseId, trimmed)
+      return { kind: 'file', imported: 1 }
+    }
+    throw new Error(`not a file or directory: ${trimmed}`)
+  }
+
+  /**
+   * Repoint a base's source: set `sourcePath` on every top-level directory
+   * container (path must be an existing directory), or on every top-level file
+   * document (path must be an existing file) when the base has no directory
+   * root. Used by the pencil button next to the base's source line.
+   */
+  async setBaseSourcePath(baseId: string, path: string): Promise<{ set: number }> {
+    const store = this.requireStore()
+    if (store.getBase(baseId) === undefined) throw new Error(`knowledge base not found: ${baseId}`)
+    const trimmed = path.trim()
+    if (trimmed.length === 0) throw new Error('path is required')
+    let st
+    try {
+      st = await stat(trimmed)
+    } catch {
+      throw new Error(`path not found: ${trimmed}`)
+    }
+    const roots = store.listDocuments(baseId).filter(doc => doc.parentDirectoryId === undefined)
+    const dirRoots = roots.filter(doc => doc.sourceType === 'directory')
+    const fileRoots = roots.filter(doc => doc.sourceType === 'file')
+    let targets: KnowledgeDocument[]
+    if (dirRoots.length > 0) {
+      if (!st.isDirectory()) throw new Error(`not a directory: ${trimmed}`)
+      targets = dirRoots
+    } else if (fileRoots.length > 0) {
+      if (!st.isFile()) throw new Error(`not a file: ${trimmed}`)
+      targets = fileRoots
+    } else {
+      throw new Error('base has no directory or file source to repoint')
+    }
+    for (const doc of targets) {
+      await store.putDocument({ ...doc, sourcePath: trimmed, updatedAt: Date.now() })
+    }
+    return { set: targets.length }
   }
 
   async addUrlDocument(request: ImportUrlRequest): Promise<KnowledgeDocument> {
@@ -1325,7 +1446,7 @@ export class KnowledgeService extends Service {
     // Fall back to the persisted text (then to reconstructed chunks) when the
     // file is gone or unreadable — a reindex must never wipe vectors for a
     // source that cannot be rebuilt.
-    const text = await this.sourceTextOf(document)
+    const { text, rawFilePath: nextRawFilePath } = await this.sourceTextOf(document)
     const config = this.getConfigFor(document.baseId)
     // Mark the document incomplete so a crash mid-reindex is resumed on the
     // next start (buildChunks persists each embedded batch; hash reuse makes
@@ -1335,6 +1456,9 @@ export class KnowledgeService extends Service {
     const { embeddingError: _staleError, errorCode: _staleCode, incomplete: _staleIncomplete, contentHash: _staleHash, ...rest } = document
     const next: KnowledgeDocument = {
       ...rest,
+      // A refreshed raw copy (e.g. sourceTextOf re-read a repointed sourcePath)
+      // must win over the stale stored path.
+      ...(nextRawFilePath !== undefined ? { rawFilePath: nextRawFilePath } : {}),
       rawText: text,
       contentHash: sha256(text),
       charCount: text.length,
@@ -1358,15 +1482,44 @@ export class KnowledgeService extends Service {
     return next
   }
 
-  /** Rebuild source text of a document: raw file first, then persisted text, then chunks. */
-  private async sourceTextOf(document: KnowledgeDocument): Promise<string> {
+  /** Rebuild source text of a document. A path-imported single file (sourcePath)
+   *  is re-read from disk first so EDITS and a repointed source (setBaseSourcePath)
+   *  are picked up, refreshing the persisted raw copy; otherwise the raw copy,
+   *  then persisted text, then reconstructed chunks are used. Returns the rebuilt
+   *  text and, when the raw copy was refreshed, its new base-relative path. */
+  private async sourceTextOf(document: KnowledgeDocument): Promise<{ text: string; rawFilePath?: string }> {
+    const store = this.requireStore()
+    // A single-file path import tracks its live source on disk. Reindex re-reads
+    // that path so edits and a repointed source (setBaseSourcePath) are actually
+    // applied — the old behavior rebuilt only from the persisted raw copy and
+    // ignored sourcePath. An unreadable path falls through to the stored copy.
+    if (document.sourceType === 'file' && document.sourcePath !== undefined) {
+      try {
+        const buffer = await readFile(document.sourcePath)
+        if (buffer.byteLength > 0) {
+          const text = await parseDocumentBuffer(buffer, document.fileName ?? document.title, document.mimeType)
+          if (text.trim().length > 0) {
+            if (store.raw !== undefined) {
+              const fileName = document.fileName ?? document.title
+              const nextRaw = await store.raw.write(document.baseId, document.id, safeRawExtension(fileName), buffer)
+              if (nextRaw !== document.rawFilePath && document.rawFilePath !== undefined) {
+                await store.raw.delete(document.rawFilePath)
+              }
+              return { text, rawFilePath: nextRaw }
+            }
+            return { text }
+          }
+        }
+      } catch (error) {
+        this.ctx.logger.warn(`knowledge: re-reading source path failed, falling back to stored copy: ${error instanceof Error ? error.message : String(error)}`)
+      }
+    }
     if (document.rawFilePath !== undefined) {
-      const store = this.requireStore()
       const raw = await store.raw?.read(document.rawFilePath)
       if (raw !== null && raw !== undefined && raw.byteLength > 0) {
         try {
           const text = await parseDocumentBuffer(raw, document.fileName ?? document.title, document.mimeType)
-          if (text.trim().length > 0) return text
+          if (text.trim().length > 0) return { text }
         } catch (error) {
           this.ctx.logger.warn(`knowledge: re-parsing raw source failed, falling back to stored text: ${error instanceof Error ? error.message : String(error)}`)
         }
@@ -1376,7 +1529,7 @@ export class KnowledgeService extends Service {
     }
     const text = document.rawText ?? reconstructFromChunks(this.requireStore().listChunksByDoc(document.id))
     if (text.trim().length === 0) throw new Error(`document "${document.title}" has no source text to reindex`)
-    return text
+    return { text }
   }
 
   /**
@@ -1385,7 +1538,9 @@ export class KnowledgeService extends Service {
    * - files/directories removed from disk are deleted from the base,
    * - new supported files are parsed and ingested (raw copy persisted),
    * - new subdirectories become containers (with their own sourcePath),
-   * - existing items are re-indexed (re-chunk + hash-reuse re-embed).
+   * - existing items are re-indexed (re-chunk + hash-reuse re-embed); when
+   *   the on-disk bytes differ from the base's persisted raw copy, the copy
+   *   is refreshed first so EDITS to source files are picked up too.
    * A missing/unreadable source keeps the existing subtree untouched (Cherry
    * skips roots whose source cannot be rebuilt). Failures are isolated per
    * entry and summarized at the end.
@@ -1464,35 +1619,71 @@ export class KnowledgeService extends Service {
         try {
           if (existing !== undefined) {
             if (this.indexing.has(existing.id)) continue
+            // Content sync with the disk: reindex alone rebuilds from the
+            // base's persisted raw copy, so edits to a source file were never
+            // picked up. When the on-disk bytes differ from the stored copy,
+            // refresh the copy and re-index from the NEW content. Equal bytes
+            // fall through to the plain reindex (rebuild from the stored
+            // copy); a failed disk read must never wipe the stored copy or
+            // the existing vectors, so it also falls through unchanged.
+            if (store.raw !== undefined && existing.rawFilePath !== undefined) {
+              try {
+                const buffer = await readFile(full)
+                const stored = await store.raw.read(existing.rawFilePath)
+                const changed = stored === null || stored === undefined || stored.byteLength === 0
+                  || !Buffer.from(stored).equals(buffer)
+                if (changed) {
+                  const text = await parseDocumentBuffer(buffer, entry.name)
+                  // Never replace a good snapshot with empty/unreadable new
+                  // content: keep the stored copy and the old vectors.
+                  if (text.trim().length > 0) {
+                    // rawFilePath already carries the `<baseId>/` prefix (it is
+                    // the full base-relative path), so strip it before writeRel,
+                    // which prepends `<baseId>/` again — otherwise the refreshed
+                    // bytes land at a doubled path and the following reindex still
+                    // rebuilds from the stale stored copy.
+                    const relRaw = existing.rawFilePath.startsWith(`${document.baseId}/`)
+                      ? existing.rawFilePath.slice(document.baseId.length + 1)
+                      : existing.rawFilePath
+                    await store.raw.writeRel(document.baseId, relRaw, buffer)
+                    await this.reindexDocument(existing.id)
+                    continue
+                  }
+                }
+              } catch {
+                // Disk or raw read failed: fall back to the stored-copy
+                // reindex below (the copy and vectors stay intact).
+              }
+            }
             await this.reindexDocument(existing.id)
           } else {
             // New file: parse + ingest like an import, with a persisted raw
-            // copy (tree-relative path) so a later reindex can rebuild from
-            // the base even if the source disk changes.
+            // copy so a later reindex can rebuild from the base even if the
+            // source disk changes. The stored path is a fresh uuid (not the
+            // tree-relative path) so it cannot collide with a sibling root's
+            // file that happens to share the same relative path.
             const buffer = await readFile(full)
             const text = await parseDocumentBuffer(buffer, entry.name)
             if (text.trim().length === 0) continue
             let rawFilePath: string | undefined
             if (store.raw !== undefined) {
-              // Resolve the outermost root's source path so the stored
-              // relative path matches the initial import's layout.
-              let root = document
-              while (root.parentDirectoryId !== undefined) {
-                const parent = store.getDocument(root.parentDirectoryId)
-                if (parent === undefined || parent.sourceType !== 'directory') break
-                root = parent
+              rawFilePath = await store.raw.write(document.baseId, crypto.randomUUID(), safeRawExtension(entry.name), buffer)
+              try {
+                await this.ingestDocument({
+                  baseId: document.baseId,
+                  title: entry.name,
+                  sourceType: 'file',
+                  fileName: entry.name,
+                  parentDirectoryId: document.id,
+                  rawFilePath,
+                  text,
+                })
+              } catch (error) {
+                // A rejected item (e.g. duplicate content) must not leave an
+                // orphaned raw copy behind.
+                await store.raw.delete(rawFilePath)
+                throw error
               }
-              const relPath = relative(root.sourcePath ?? source, full).replace(/\\/g, '/')
-              rawFilePath = await store.raw.writeRel(document.baseId, relPath, buffer)
-              await this.ingestDocument({
-                baseId: document.baseId,
-                title: entry.name,
-                sourceType: 'file',
-                fileName: entry.name,
-                parentDirectoryId: document.id,
-                rawFilePath,
-                text,
-              })
             } else {
               await this.ingestDocument({
                 baseId: document.baseId,
@@ -2213,6 +2404,7 @@ export class KnowledgeService extends Service {
     return {
       ...(baseId !== undefined ? { baseId } : {}),
       documentCount: documents.length,
+      storedDocCount: documents.reduce((sum, doc) => sum + (doc.rawFilePath !== undefined ? 1 : 0), 0),
       chunkCount: chunkStats.count,
       charCount,
       tokenCount,
@@ -2747,6 +2939,8 @@ export class KnowledgeService extends Service {
     text: string
     /** Base-relative path of the persisted original source bytes (file docs). */
     rawFilePath?: string
+    /** Absolute source path the item was imported from (file/path imports). */
+    sourcePath?: string
     /** Pre-created placeholder id (already stored, shown while embedding). */
     placeholderId?: string
   }, signal?: AbortSignal): Promise<KnowledgeDocument> {
@@ -2791,6 +2985,7 @@ export class KnowledgeService extends Service {
         ...(input.url !== undefined ? { url: input.url } : {}),
         ...(input.parentDirectoryId !== undefined ? { parentDirectoryId: input.parentDirectoryId } : {}),
         ...(input.rawFilePath !== undefined ? { rawFilePath: input.rawFilePath } : {}),
+        ...(input.sourcePath !== undefined ? { sourcePath: input.sourcePath } : {}),
         contentHash,
         rawText: input.text,
         charCount: input.text.length,
@@ -3069,6 +3264,39 @@ function effectiveMode(requested: SearchMode, ranked: readonly RankedHit[]): Sea
   if (requested === 'hybrid') return hybrid ? 'hybrid' : 'lexical'
   // auto
   return hybrid ? 'hybrid' : 'lexical'
+}
+
+/** Bounded list of a base's top-level sources (directory roots / files / URLs /
+ *  text nodes), for the detail header. Nested children are covered by their
+ *  root, so only `parentDirectoryId === undefined` items are listed. */
+function baseSourceLines(documents: KnowledgeDocument[]): BaseSourceInfo[] {
+  const MAX = 4
+  const seen = new Set<string>()
+  const lines: BaseSourceInfo[] = []
+  for (const doc of documents) {
+    if (doc.parentDirectoryId !== undefined) continue
+    let kind: DocumentSourceType
+    let text: string
+    if (doc.sourceType === 'directory') {
+      kind = 'directory'
+      text = doc.sourcePath ?? doc.title
+    } else if (doc.sourceType === 'url') {
+      kind = 'url'
+      text = doc.url ?? doc.title
+    } else if (doc.sourceType === 'file') {
+      kind = 'file'
+      text = doc.sourcePath ?? doc.fileName ?? doc.title
+    } else {
+      kind = 'text'
+      text = 'node'
+    }
+    const key = `${kind}:${text}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    lines.push({ kind, text })
+    if (lines.length >= MAX) break
+  }
+  return lines
 }
 
 function sha256(text: string): string {

--- a/src/knowledge/store.ts
+++ b/src/knowledge/store.ts
@@ -10,8 +10,8 @@
  */
 
 import type { Domain, DomainSpec } from '@deepseek-ai/dsh-storage-domain'
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { dirname, extname, join } from 'node:path'
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { dirname, extname, join, relative } from 'node:path'
 import { knowledgeDomainSpec, TABLES } from './domain.js'
 import type { ConfigOverrides } from './domain.js'
 import { ChunkDatabase, hashEmbeddingText, legacyChunkFilePath, migrateLegacyChunkFile, resolveChunkStorePath, searchTextOf } from './chunkdb.js'
@@ -47,6 +47,8 @@ export interface RawFileStore {
   writeRel(baseId: string, relativePath: string, bytes: Uint8Array): Promise<string>
   /** Read a document's source bytes back (null when absent). */
   read(relativePath: string): Promise<Uint8Array | null>
+  /** Every stored base-relative path (for orphan-raw reconciliation). */
+  listAll(): Promise<string[]>
   /** Remove one document's source file by its stored relative path (missing = no-op). */
   delete(relativePath: string): Promise<void>
   /** Remove every source file of a base. */
@@ -90,6 +92,25 @@ export class RawFileStorage implements RawFileStore {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
       throw error
     }
+  }
+
+  async listAll(): Promise<string[]> {
+    const out: string[] = []
+    const walk = async (dir: string): Promise<void> => {
+      let entries
+      try {
+        entries = await readdir(dir, { withFileTypes: true })
+      } catch {
+        return
+      }
+      for (const entry of entries) {
+        const full = join(dir, entry.name)
+        if (entry.isDirectory()) await walk(full)
+        else out.push(relative(this.root, full).replace(/\\/g, '/'))
+      }
+    }
+    await walk(this.root)
+    return out
   }
 
   async delete(relativePath: string): Promise<void> {
@@ -153,6 +174,8 @@ export interface Store {
    *   before/during parse) — re-indexed by the service after startup.
    */
   recoverInterruptedImports(startedAt: number): Promise<{ removed: number; resume: string[] }>
+  /** Remove raw source copies no document references (orphans from failed/duplicate imports). */
+  reconcileOrphanRaws(): Promise<number>
   /** Aggregate chunk stats without loading chunk rows. */
   chunkStats(baseIds: readonly string[]): ChunkStats
   /** SQL-backed retrieval lanes (FTS5 + vector scan); absent on in-memory stores. */
@@ -220,6 +243,8 @@ export async function openStore(
       const recovery = await store.recoverInterruptedImports(Date.now())
       if (recovery.removed > 0) console.warn(`dsh-knowledge: removed ${recovery.removed} incomplete import(s) left by an interrupted run`)
       await store.reconcileChunkCounts()
+      const orphaned = await store.reconcileOrphanRaws()
+      if (orphaned > 0) console.warn(`dsh-knowledge: removed ${orphaned} orphaned raw source file(s) no document referenced`)
       return store
     } catch (error) {
       // Fall through to memory on any open failure (no backend, version mismatch, …).
@@ -379,6 +404,23 @@ class DomainStore implements Store {
 
   docChunkStatus(baseId: string): { withChunks: Set<string>; missingEmbedding: Set<string> } {
     return this.chunkDb.docChunkStatus(baseId)
+  }
+
+  async reconcileOrphanRaws(): Promise<number> {
+    const referenced = new Set<string>()
+    for (const base of this.listBases()) {
+      for (const doc of this.listDocuments(base.id)) {
+        if (doc.rawFilePath !== undefined) referenced.add(doc.rawFilePath)
+      }
+    }
+    let removed = 0
+    for (const rel of await this.rawStore.listAll()) {
+      if (!referenced.has(rel)) {
+        await this.rawStore.delete(rel)
+        removed += 1
+      }
+    }
+    return removed
   }
 
   chunkStats(baseIds: readonly string[]): ChunkStats {
@@ -591,6 +633,11 @@ class MemoryStore implements Store {
       removed += 1
     }
     return { removed, resume }
+  }
+
+  async reconcileOrphanRaws(): Promise<number> {
+    // In-memory store keeps no raw files on disk.
+    return 0
   }
 
   docChunkStatus(baseId: string): { withChunks: Set<string>; missingEmbedding: Set<string> } {

--- a/src/knowledge/types.ts
+++ b/src/knowledge/types.ts
@@ -315,6 +315,15 @@ export interface DocumentSummary {
   readonly updatedAt?: number
 }
 
+/** One origin line for a base: where its content came from (shown under the
+ *  base name in the detail header — path for directories/files, link for URLs,
+ *  "node" for manually added text). */
+export interface BaseSourceInfo {
+  readonly kind: DocumentSourceType
+  /** Directory path / file name / URL / 'node'. */
+  readonly text: string
+}
+
 /** Summary of one knowledge base, for listing UIs. */
 export interface BaseSummary {
   readonly id: string
@@ -322,10 +331,14 @@ export interface BaseSummary {
   readonly description: string
   readonly group?: string
   readonly documentCount: number
+  /** Documents with a persisted raw source copy (actually imported & stored). */
+  readonly storedDocCount: number
   readonly chunkCount: number
   readonly charCount: number
   readonly tokenCount: number
   readonly config?: BaseConfig
+  /** Top-level sources of the base's content, for display (bounded). */
+  readonly sourceInfo?: BaseSourceInfo[]
   readonly createdAt: number
   readonly updatedAt: number
 }
@@ -334,6 +347,8 @@ export interface BaseSummary {
 export interface BaseStats {
   readonly baseId?: string
   readonly documentCount: number
+  /** Documents with a persisted raw source copy (actually imported & stored). */
+  readonly storedDocCount: number
   readonly chunkCount: number
   readonly charCount: number
   readonly tokenCount: number

--- a/src/knowledge/types.ts
+++ b/src/knowledge/types.ts
@@ -319,9 +319,13 @@ export interface DocumentSummary {
  *  base name in the detail header — path for directories/files, link for URLs,
  *  "node" for manually added text). */
 export interface BaseSourceInfo {
+  /** Top-level document/container that owns this source. */
+  readonly sourceId: string
   readonly kind: DocumentSourceType
   /** Directory path / file name / URL / 'node'. */
   readonly text: string
+  /** Absolute tracked path when this source can be repointed. */
+  readonly sourcePath?: string
 }
 
 /** Summary of one knowledge base, for listing UIs. */

--- a/src/tool-knowledge/index.ts
+++ b/src/tool-knowledge/index.ts
@@ -50,11 +50,12 @@ const contextWindowSchema = {
 function aggregateStats(rows: ReadonlyArray<ReturnType<KnowledgeService['stats']>>): ReturnType<KnowledgeService['stats']> {
   return rows.reduce<ReturnType<KnowledgeService['stats']>>((total, row) => ({
     documentCount: total.documentCount + row.documentCount,
+    storedDocCount: total.storedDocCount + row.storedDocCount,
     chunkCount: total.chunkCount + row.chunkCount,
     charCount: total.charCount + row.charCount,
     tokenCount: total.tokenCount + row.tokenCount,
     embedded: total.embedded || row.embedded,
-  }), { documentCount: 0, chunkCount: 0, charCount: 0, tokenCount: 0, embedded: false })
+  }), { documentCount: 0, storedDocCount: 0, chunkCount: 0, charCount: 0, tokenCount: 0, embedded: false })
 }
 
 function clampToolInt(value: number | undefined, min: number, max: number, fallback: number): number {

--- a/src/ui/client/KnowledgeSection.tsx
+++ b/src/ui/client/KnowledgeSection.tsx
@@ -13,6 +13,7 @@ import type { CSSProperties, DragEvent } from 'react'
 import { serializeContextWindow } from '../../knowledge/context.js'
 import { KnowledgeApi } from './api.js'
 import type {
+  BaseSourceInfo,
   BaseStats,
   BaseSummary,
   ChunkView,
@@ -143,7 +144,7 @@ type DialogState =
   | { kind: 'confirmDeleteGroup'; group: string }
   | { kind: 'addUrl' }
   | { kind: 'addPath' }
-  | { kind: 'editSourcePath'; initial: string }
+  | { kind: 'editSourcePath'; sourceId: string; initial: string }
   | { kind: 'addText' }
   | null
 
@@ -557,7 +558,13 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
       try {
         const result = await api.importFromPath(selectedBaseId, trimmed)
         setDialog(null)
-        notify('success', `${t('tabPath')}: ${result.kind === 'directory' ? `${result.imported} ${t('docCount')}` : result.imported}`)
+        if (result.errors.length > 0) {
+          notify('warning', t('pathImportPartial')
+            .replace('{count}', String(result.imported))
+            .replace('{errors}', String(result.errors.length)))
+        } else {
+          notify('success', `${t('tabPath')}: ${result.kind === 'directory' ? `${result.imported} ${t('docCount')}` : result.imported}`)
+        }
         await refreshBases()
         await reloadDocuments()
       } catch (err) {
@@ -566,20 +573,19 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
     })
   }, [api, run, refreshBases, reloadDocuments, notify, selectedBaseId, t])
 
-  const promptForSourcePath = useCallback((): void => {
+  const promptForSourcePath = useCallback((source: BaseSourceInfo): void => {
     if (selectedBaseId === null) return
-    const currentBase = bases.find(base => base.id === selectedBaseId)
-    const current = currentBase?.sourceInfo?.map(source => source.text).find(Boolean) ?? ''
-    setDialog({ kind: 'editSourcePath', initial: current })
-  }, [bases, selectedBaseId])
+    if (source.sourcePath === undefined) return
+    setDialog({ kind: 'editSourcePath', sourceId: source.sourceId, initial: source.sourcePath })
+  }, [selectedBaseId])
 
-  const editSourcePath = useCallback((path: string): void => {
+  const editSourcePath = useCallback((sourceId: string, path: string): void => {
     if (selectedBaseId === null) return
     const trimmed = path.trim()
     if (trimmed === '') return
     void run(async () => {
       try {
-        const result = await api.setBaseSourcePath(selectedBaseId, trimmed)
+        const result = await api.setBaseSourcePath(selectedBaseId, sourceId, trimmed)
         setDialog(null)
         notify('success', `${t('sourcePathEdit')}: ${result.set}`)
         await refreshBases()
@@ -1343,21 +1349,23 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                   repoints the base's source path (validated server-side). */}
               {(selectedBase.sourceInfo ?? []).length > 0 && (
                 <div style={style.baseSourceRow}>
-                  {selectedBase.sourceInfo!.map((source, i) => (
-                    <span key={i} style={style.baseSourceItem}>
+                  {selectedBase.sourceInfo!.map(source => (
+                    <span key={source.sourceId} style={style.baseSourceItem}>
                       <span style={style.baseSourceGlyph}>{baseSourceGlyph(source.kind)}</span>
                       <span style={style.baseSourceText} title={source.text}>{source.text}</span>
+                      {source.sourcePath !== undefined && (
+                        <button
+                          className="kb-iconbtn"
+                          style={{ ...style.baseSourceEdit, ...style.iconOnlyButton }}
+                          title={t('sourcePathEdit')}
+                          aria-label={`${t('sourcePathEdit')}: ${source.text}`}
+                          onClick={() => promptForSourcePath(source)}
+                        >
+                          <IconPencil size={11} />
+                        </button>
+                      )}
                     </span>
                   ))}
-                  <button
-                    className="kb-iconbtn"
-                    style={{ ...style.baseSourceEdit, ...style.iconOnlyButton }}
-                    title={t('sourcePathEdit')}
-                    aria-label={t('sourcePathEdit')}
-                    onClick={promptForSourcePath}
-                  >
-                    <IconPencil size={11} />
-                  </button>
                 </div>
               )}
 
@@ -1849,7 +1857,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
           title={t('sourcePathEdit')}
           label={t('sourcePathPrompt')}
           initial={dialog.initial}
-          onOk={(value) => { setDialog(null); editSourcePath(value) }}
+          onOk={(value) => { setDialog(null); editSourcePath(dialog.sourceId, value) }}
           onClose={() => setDialog(null)}
         />
       )}

--- a/src/ui/client/KnowledgeSection.tsx
+++ b/src/ui/client/KnowledgeSection.tsx
@@ -35,9 +35,12 @@ import {
 import {
   IconBook,
   IconCheck,
+  IconDoc,
   IconEye,
   IconFlask,
+  IconLink,
   IconMore,
+  IconPencil,
   IconPlus,
   IconRefresh,
   IconSearch,
@@ -139,6 +142,8 @@ type DialogState =
   | { kind: 'renameGroup'; group: string }
   | { kind: 'confirmDeleteGroup'; group: string }
   | { kind: 'addUrl' }
+  | { kind: 'addPath' }
+  | { kind: 'editSourcePath'; initial: string }
   | { kind: 'addText' }
   | null
 
@@ -193,6 +198,10 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
   const [localModelStatus, setLocalModelStatus] = useState<LocalModelStatus | null>(null)
   const [docLimit, setDocLimit] = useState(100)
   const [navWidth, setNavWidth] = useState(272)
+  // Sliding side panels (settings / recall test) are resizable too; the width
+  // is shared between them so the user's preference sticks while the panel is
+  // open.
+  const [sidePanelWidth, setSidePanelWidth] = useState(460)
   const [dragOver, setDragOver] = useState(false)
   const dragDepth = useRef(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -210,9 +219,16 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
   const notify = useCallback((kind: Toast['kind'], text: string): void => {
     const id = Date.now() + Math.random()
     setToasts(prev => [...prev, { id, kind, text }])
+    // Errors/warnings carry codes the user may need to copy, so they stay
+    // until dismissed manually; success/info auto-clear after a short delay.
+    if (kind === 'error' || kind === 'warning') return
     window.setTimeout(() => {
       setToasts(prev => prev.filter(toast => toast.id !== id))
     }, 3200)
+  }, [])
+
+  const dismissToast = useCallback((id: number): void => {
+    setToasts(prev => prev.filter(toast => toast.id !== id))
   }, [])
 
   const run = useCallback(async (fn: () => Promise<void>): Promise<void> => {
@@ -261,6 +277,22 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
     document.addEventListener('mousemove', onMove)
     document.addEventListener('mouseup', onUp)
   }, [navWidth])
+
+  const onSideResizeStart = useCallback((event: React.MouseEvent): void => {
+    event.preventDefault()
+    const startX = event.clientX
+    const startWidth = sidePanelWidth
+    const onMove = (ev: MouseEvent): void => {
+      // Panel sits on the right edge; dragging left grows it, right shrinks.
+      setSidePanelWidth(Math.min(680, Math.max(360, startWidth - (ev.clientX - startX))))
+    }
+    const onUp = (): void => {
+      document.removeEventListener('mousemove', onMove)
+      document.removeEventListener('mouseup', onUp)
+    }
+    document.addEventListener('mousemove', onMove)
+    document.addEventListener('mouseup', onUp)
+  }, [sidePanelWidth])
 
   // Local embedding readiness, for the empty-state guidance.
   useEffect(() => {
@@ -511,6 +543,51 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
       }
     })
   }, [api, run, onImported, notify, selectedBaseId, currentDirectoryId])
+
+  const promptForPath = useCallback((): void => {
+    if (selectedBaseId === null) return
+    setDialog({ kind: 'addPath' })
+  }, [selectedBaseId])
+
+  const addPath = useCallback((path: string): void => {
+    if (selectedBaseId === null) return
+    const trimmed = path.trim()
+    if (trimmed === '') return
+    void run(async () => {
+      try {
+        const result = await api.importFromPath(selectedBaseId, trimmed)
+        setDialog(null)
+        notify('success', `${t('tabPath')}: ${result.kind === 'directory' ? `${result.imported} ${t('docCount')}` : result.imported}`)
+        await refreshBases()
+        await reloadDocuments()
+      } catch (err) {
+        notify('error', err instanceof Error ? err.message : String(err))
+      }
+    })
+  }, [api, run, refreshBases, reloadDocuments, notify, selectedBaseId, t])
+
+  const promptForSourcePath = useCallback((): void => {
+    if (selectedBaseId === null) return
+    const currentBase = bases.find(base => base.id === selectedBaseId)
+    const current = currentBase?.sourceInfo?.map(source => source.text).find(Boolean) ?? ''
+    setDialog({ kind: 'editSourcePath', initial: current })
+  }, [bases, selectedBaseId])
+
+  const editSourcePath = useCallback((path: string): void => {
+    if (selectedBaseId === null) return
+    const trimmed = path.trim()
+    if (trimmed === '') return
+    void run(async () => {
+      try {
+        const result = await api.setBaseSourcePath(selectedBaseId, trimmed)
+        setDialog(null)
+        notify('success', `${t('sourcePathEdit')}: ${result.set}`)
+        await refreshBases()
+      } catch (err) {
+        notify('error', err instanceof Error ? err.message : String(err))
+      }
+    })
+  }, [api, run, refreshBases, notify, selectedBaseId, t])
 
   const addText = useCallback((title: string, content: string): void => {
     if (selectedBaseId === null) return
@@ -895,7 +972,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
             apiKey: config.apiKey,
           })
         } catch (error) {
-          notify('error', `${t('dimensionProbeFailed')}：${error instanceof Error ? error.message : String(error)}`)
+          notify('error', `${t('dimensionProbeFailed')}: ${error instanceof Error ? error.message : String(error)}`)
           return
         }
       }
@@ -1047,6 +1124,15 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
     { key: 'delete', label: t('delete'), danger: true, onSelect: () => setDialog({ kind: 'confirmDeleteGroup', group }) },
   ]
 
+  const baseSourceGlyph = (kind: 'text' | 'file' | 'url' | 'directory'): JSX.Element => {
+    switch (kind) {
+      case 'directory': return <IconFolderOpen size={12} />
+      case 'url': return <IconLink size={12} />
+      case 'file': return <IconDoc size={12} />
+      default: return <IconPencil size={12} />
+    }
+  }
+
   const renderBaseRow = (base: BaseSummary): JSX.Element => (
     <div
       key={base.id}
@@ -1076,6 +1162,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
   const addSourceMenu: MenuEntry[] = [
     { key: 'file', label: t('tabFile'), onSelect: () => fileInputRef.current?.click() },
     { key: 'dir', label: t('tabDir'), onSelect: () => dirInputRef.current?.click() },
+    { key: 'path', label: t('tabPath'), onSelect: () => promptForPath() },
     { key: 'url', label: t('tabUrl'), onSelect: () => promptForUrl() },
     { key: 'text', label: t('tabText'), onSelect: () => setDialog({ kind: 'addText' }) },
   ]
@@ -1130,7 +1217,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
         </span>
       </div>
 
-      <Toasts toasts={toasts} />
+      <Toasts toasts={toasts} onDismiss={dismissToast} />
 
       <div style={style.body}>
         <aside style={{ ...style.sidebar, width: navWidth }} className="kb-scroll">
@@ -1188,9 +1275,11 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
         </aside>
 
         <div
+          className="kb-sash"
           onMouseDown={onNavResizeStart}
-          style={{ width: 5, cursor: 'col-resize', flexShrink: 0, background: 'transparent', borderRight: `1px solid ${C.border}` }}
+          style={{ width: 8, cursor: 'col-resize', flexShrink: 0, background: 'transparent', borderRight: `1px solid ${C.border}` }}
           title={t('dragResize')}
+          aria-label={t('dragResize')}
         />
 
         <main style={style.main} className="kb-scroll">
@@ -1249,6 +1338,29 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                 </span>
               </div>
 
+              {/* Base origin(s), between the name and the stats: directory
+                  path / file / URL / node for manually added text. The pencil
+                  repoints the base's source path (validated server-side). */}
+              {(selectedBase.sourceInfo ?? []).length > 0 && (
+                <div style={style.baseSourceRow}>
+                  {selectedBase.sourceInfo!.map((source, i) => (
+                    <span key={i} style={style.baseSourceItem}>
+                      <span style={style.baseSourceGlyph}>{baseSourceGlyph(source.kind)}</span>
+                      <span style={style.baseSourceText} title={source.text}>{source.text}</span>
+                    </span>
+                  ))}
+                  <button
+                    className="kb-iconbtn"
+                    style={{ ...style.baseSourceEdit, ...style.iconOnlyButton }}
+                    title={t('sourcePathEdit')}
+                    aria-label={t('sourcePathEdit')}
+                    onClick={promptForSourcePath}
+                  >
+                    <IconPencil size={11} />
+                  </button>
+                </div>
+              )}
+
               {selectedDocId !== null && selectedDoc !== null ? (
                 <DocumentDetailPanel
                   key={selectedDoc.id}
@@ -1265,7 +1377,8 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                 <>
                   {stats !== null && (
                     <div style={style.statsRow}>
-                      <StatChip value={stats.documentCount} label={t('statsDocs')} />
+                      <StatChip value={stats.documentCount} label={t('statsSourceDocs')} title={t('statsSourceDocsTitle')} />
+                      <StatChip value={stats.storedDocCount} label={t('statsStoredDocs')} title={t('statsStoredDocsTitle')} />
                       <StatChip value={stats.chunkCount} label={t('statsChunks')} />
                       <StatChip value={stats.tokenCount} label={t('statsTokens')} />
                       <StatChip value={formatSize(stats.charCount)} label={t('statsChars')} />
@@ -1300,7 +1413,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                         background: 'color-mix(in srgb, var(--dsw-alias-brand-primary, #3b6ef6) 8%, transparent)',
                         borderRadius: 10, pointerEvents: 'none',
                       }}>
-                        <span style={{ fontSize: 14, fontWeight: 600, color: C.accent, background: 'var(--dsw-bg-base, #fff)', padding: '8px 16px', borderRadius: 999, boxShadow: '0 2px 10px rgba(0,0,0,0.12)' }}>
+                        <span style={{ fontSize: 14, fontWeight: 600, color: C.accent, background: C.bg, padding: '8px 16px', borderRadius: 999, boxShadow: '0 2px 10px rgba(0,0,0,0.12)' }}>
                           {t('dragToUpload')}
                         </span>
                       </div>
@@ -1319,7 +1432,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                             <IconRefresh size={13} />{t('bulkReindex')}
                           </button>
                           <button
-                            style={style.primaryDanger}
+                            className="kb-danger-primary" style={style.primaryDanger}
                             disabled={busy}
                             onClick={() => setDialog({ kind: 'confirmBulkDelete', count: checkedDocs.length })}
                           >
@@ -1331,7 +1444,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                         <span style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
                           <span style={{ fontSize: 11, color: C.muted }}>
-                            {t('updatedAtText')} {formatRelativeTime(selectedBase.updatedAt)}
+                            {t('updatedAtText')} {formatRelativeTime(selectedBase.updatedAt, t)}
                           </span>
                           {selectedBaseLocalModel !== null && localModelStatus !== null && localModelStatus.status !== 'ready' && (
                             <span
@@ -1360,7 +1473,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                         </span>
                         <PopoverMenu
                           align="end"
-                          trigger={<button style={style.primary} disabled={busy}><IconPlus />{t('addSource')}</button>}
+                          trigger={<button className="kb-primary" style={style.primary} disabled={busy}><IconPlus />{t('addSource')}</button>}
                           entries={addSourceMenu}
                         />
                       </div>
@@ -1382,7 +1495,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                               <div style={{ display: 'flex', justifyContent: 'center' }}>
                                 <PopoverMenu
                                   align="start"
-                                  trigger={<button style={style.primary} disabled={busy}><IconPlus />{t('addSource')}</button>}
+                                  trigger={<button className="kb-primary" style={style.primary} disabled={busy}><IconPlus />{t('addSource')}</button>}
                                   entries={addSourceMenu}
                                 />
                               </div>
@@ -1547,7 +1660,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                                         style={{ display: 'inline-flex', alignItems: 'center', gap: 3, fontSize: 11, color: C.danger }}
                                         tabIndex={0}
                                         role="img"
-                                        aria-label={`${t('embeddingFailed')}：${reason}`}
+                                        aria-label={`${t('embeddingFailed')}: ${reason}`}
                                         title={reason}
                                       >
                                         ✕ {t('embeddingFailed')}
@@ -1564,7 +1677,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                                   )
                                 })()}
                                 <span style={{ fontSize: 11, color: C.muted }}>
-                                  {doc.updatedAt !== undefined ? formatRelativeTime(doc.updatedAt) : ''}
+                                  {doc.updatedAt !== undefined ? formatRelativeTime(doc.updatedAt, t) : ''}
                                 </span>
                                 <PopoverMenu
                                   align="end"
@@ -1576,7 +1689,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
                             {hasMoreDocuments && (
                               <div style={{ display: 'flex', justifyContent: 'center', padding: '10px 0 4px' }}>
                                 <button className="kb-row" style={style.button} onClick={() => setDocLimit(v => v + 100)}>
-                                  {t('loadMore')}（{renderedDocuments.length}/{visibleDocuments.length}）
+                                  {t('loadMore')} ({renderedDocuments.length}/{visibleDocuments.length})
                                 </button>
                               </div>
                             )}
@@ -1595,7 +1708,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
         </main>
 
         {ragOpen && globalConfig !== null && selectedBase !== null && (
-          <SidePanel title={t('baseSettings')} onClose={() => setRagOpen(false)}>
+          <SidePanel title={t('baseSettings')} onClose={() => setRagOpen(false)} width={sidePanelWidth} onResizeWidth={onSideResizeStart}>
             <RagConfigPanel
               base={selectedBase}
               globalConfig={globalConfig}
@@ -1608,7 +1721,7 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
         )}
 
         {recallOpen && selectedBase !== null && (
-          <SidePanel title={t('recallTest')} onClose={() => setRecallOpen(false)}>
+          <SidePanel title={t('recallTest')} onClose={() => setRecallOpen(false)} width={sidePanelWidth} onResizeWidth={onSideResizeStart}>
             <RecallPanel
               t={t}
               busy={busy}
@@ -1722,6 +1835,24 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
           onClose={() => setDialog(null)}
         />
       )}
+      {dialog?.kind === 'addPath' && (
+        <PromptDialog
+          title={t('tabPath')}
+          label={t('pathDesc')}
+          initial=""
+          onOk={(value) => { setDialog(null); addPath(value) }}
+          onClose={() => setDialog(null)}
+        />
+      )}
+      {dialog?.kind === 'editSourcePath' && (
+        <PromptDialog
+          title={t('sourcePathEdit')}
+          label={t('sourcePathPrompt')}
+          initial={dialog.initial}
+          onOk={(value) => { setDialog(null); editSourcePath(value) }}
+          onClose={() => setDialog(null)}
+        />
+      )}
       {dialog?.kind === 'addText' && (
         <TextDocumentDialog
           t={t}
@@ -1758,10 +1889,10 @@ function PanelBody(props: { api: KnowledgeApi; t: Translate; onClose: () => void
               </ul>
             )}
             <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
-              <button style={style.primary} disabled={pendingResolution !== null} onClick={() => resolveConflict('rename')}>
+              <button className="kb-primary" style={style.primary} disabled={pendingResolution !== null} onClick={() => resolveConflict('rename')}>
                 {pendingResolution === 'rename' ? t('resolvingConflict') : t('conflictKeepAll')}
               </button>
-              <button style={style.primaryDanger} disabled={pendingResolution !== null} onClick={() => resolveConflict('replace')}>
+              <button className="kb-danger-primary" style={style.primaryDanger} disabled={pendingResolution !== null} onClick={() => resolveConflict('replace')}>
                 {pendingResolution === 'replace' ? t('resolvingConflict') : t('conflictReplaceAll')}
               </button>
               <button style={style.button} disabled={pendingResolution !== null} onClick={() => resolveConflict('cancel')}>
@@ -1838,11 +1969,11 @@ function failureReasonLabel(doc: DocumentSummary, t: Translate): string {
     case 'interrupted':
       return t('errorInterrupted')
     case 'dimension_mismatch':
-      return `${t('errorDimensionMismatch')}：${doc.embeddingError ?? ''}`
+      return `${t('errorDimensionMismatch')}: ${doc.embeddingError ?? ''}`
     case 'parse_failed':
-      return `${t('errorParseFailed')}：${doc.embeddingError ?? ''}`
+      return `${t('errorParseFailed')}: ${doc.embeddingError ?? ''}`
     case 'embedding_provider':
-      return `${t('errorEmbeddingProvider')}：${doc.embeddingError ?? ''}`
+      return `${t('errorEmbeddingProvider')}: ${doc.embeddingError ?? ''}`
     default:
       return doc.embeddingError ?? t('embeddingFailed')
   }
@@ -1895,7 +2026,7 @@ function RecallPanel(props: {
             >🕘</button>
           )}
         </div>
-        <button style={style.primary} disabled={!canSearch} onClick={() => props.onSearch(props.searchQuery)}>⚡{t('searchButton')}</button>
+        <button className="kb-primary" style={style.primary} disabled={!canSearch} onClick={() => props.onSearch(props.searchQuery)}>⚡{t('searchButton')}</button>
 
         {hasHistory && historyOpen && (
           <div style={{ position: 'absolute', top: 'calc(100% + 4px)', left: 0, right: 0, zIndex: 40, maxHeight: 220, overflowY: 'auto', background: C.overlay, border: `1px solid ${C.border}`, borderRadius: 10, boxShadow: '0 10px 32px rgba(0,0,0,0.18)', padding: 4 }}>
@@ -1964,7 +2095,7 @@ function RecallResultCard(props: { hit: SearchHit; index: number; t: Translate }
     try {
       // Copy a full Markdown citation (quote + source) so the excerpt can be
       // pasted into the conversation with its traceable source line.
-      await navigator.clipboard.writeText(citationMarkdown(hit))
+      await navigator.clipboard.writeText(citationMarkdown(hit, t))
       setCopied(true)
       window.setTimeout(() => setCopied(false), 2000)
     } catch {
@@ -1998,23 +2129,47 @@ function RecallResultCard(props: { hit: SearchHit; index: number; t: Translate }
   )
 }
 
-function SidePanel(props: { title: string; onClose: () => void; children: React.ReactNode }): JSX.Element {
+function SidePanel(props: {
+  title: string
+  onClose: () => void
+  children: React.ReactNode
+  width?: number
+  onResizeWidth?: (event: React.MouseEvent) => void
+}): JSX.Element {
+  const resizable = props.onResizeWidth !== undefined
   return (
     <div style={style.sidePanelScrim} onClick={props.onClose}>
-      <div style={style.sidePanel} onClick={(e) => e.stopPropagation()}>
-        <div style={style.sidePanelHeader}>
-          <span style={{ fontSize: 14, fontWeight: 600 }}>{props.title}</span>
-          <button className="kb-row" style={style.closeButton} onClick={props.onClose} aria-label="close">✕</button>
+      <div
+        style={{ ...style.sidePanel, width: props.width ?? 460, flexDirection: 'row' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {resizable && (
+          <div
+            className="kb-sash"
+            onMouseDown={props.onResizeWidth}
+            style={{
+              width: 8, cursor: 'col-resize', flexShrink: 0, alignSelf: 'stretch',
+              position: 'relative', zIndex: 6, borderRight: `1px solid ${C.border}`,
+            }}
+            title="Drag to resize"
+            aria-label="Drag to resize"
+          />
+        )}
+        <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+          <div style={style.sidePanelHeader}>
+            <span style={{ fontSize: 14, fontWeight: 600 }}>{props.title}</span>
+            <button className="kb-row" style={style.closeButton} onClick={props.onClose} aria-label="close">✕</button>
+          </div>
+          <div style={style.sidePanelBody} className="kb-scroll">{props.children}</div>
         </div>
-        <div style={style.sidePanelBody} className="kb-scroll">{props.children}</div>
       </div>
     </div>
   )
 }
 
-function StatChip(props: { value: string | number; label: string }): JSX.Element {
+function StatChip(props: { value: string | number; label: string; title?: string }): JSX.Element {
   return (
-    <span style={style.statChip}>
+    <span style={style.statChip} title={props.title}>
       <span style={style.statValue}>{props.value}</span>
       <span style={style.statLabel}>{props.label}</span>
     </span>
@@ -2290,7 +2445,7 @@ function DocumentDetailPanel(props: {
                 return (
                   <div key={chunk.id} style={{ border: `1px solid ${C.border}`, borderRadius: 8, marginBottom: 8, background: C.surface }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px', borderBottom: `1px solid ${C.border}` }}>
-                      <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', minWidth: 20, height: 20, padding: '0 6px', borderRadius: 5, background: C.accent, color: '#fff', fontSize: 11, fontWeight: 600 }}>{chunk.index + 1}</span>
+                      <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', minWidth: 20, height: 20, padding: '0 6px', borderRadius: 5, background: C.accent, color: 'var(--dsw-alias-label-primary-foreground, #fff)', fontSize: 11, fontWeight: 600 }}>{chunk.index + 1}</span>
                       <span style={{ flex: 1, minWidth: 0, fontSize: 11, color: C.muted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {chunk.heading !== undefined ? chunk.heading : ''}
                       </span>
@@ -2338,12 +2493,12 @@ function scoreColor(score: number, palette: typeof C): string {
 }
 
 /** Markdown citation block for one search hit: quote + source line. */
-function citationMarkdown(hit: SearchHit): string {
+function citationMarkdown(hit: SearchHit, t: Translate): string {
   const quote = hit.text.split('\n').map(line => `> ${line}`).join('\n')
   const source = hit.heading !== undefined && hit.heading.length > 0
     ? `${hit.documentTitle} / ${hit.heading}`
     : hit.documentTitle
-  return `${quote}\n>\n> — ${source}（知识库 ${hit.baseId}）`
+  return `${quote}\n>\n> — ${source}${t('citationSource').replace('{id}', hit.baseId)}`
 }
 
 function highlightMatches(text: string, query: string, markStyle: CSSProperties): JSX.Element {

--- a/src/ui/client/LocalModelsSection.tsx
+++ b/src/ui/client/LocalModelsSection.tsx
@@ -125,7 +125,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
   const browseCacheDir = useCallback(async (): Promise<void> => {
     setError(null)
     if (props.workspaces === undefined) {
-      setError('文件夹选择不可用（当前环境无目录选择能力）')
+      setError(t('cacheDirPickUnavailable'))
       return
     }
     try {
@@ -134,7 +134,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     }
-  }, [props.workspaces])
+  }, [props.workspaces, t])
 
   const openCacheDir = useCallback(async (): Promise<void> => {
     setError(null)
@@ -155,7 +155,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
       setCacheDir(result.to)
       setError(null)
       if (result.moved > 0) {
-        setError(`${result.moved} 个模型目录已迁移到 ${result.to}`)
+        setError(t('cacheDirMigrated').replace('{count}', String(result.moved)).replace('{to}', result.to))
       } else {
         // Also silent before: a no-op migration (same dir, or the target
         // already holds the entries) showed nothing at all.
@@ -180,6 +180,24 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
       setOllamaBusy(false)
     }
   }, [api, ollamaBase, t])
+
+  // Make the Ollama server used here the global embedding default, so new
+  // bases inherit it (per-base settings only override it). Non-fatal on
+  // error — model management must keep working even if persistence fails.
+  const persistOllamaDefault = useCallback((): void => {
+    const base = ollamaBase.trim()
+    if (base === '') return
+    void api.setConfig({ embeddingProvider: 'ollama', embeddingBaseUrl: base }).catch(() => {})
+    // Also default the embedding model so a fresh base embeds out of the box:
+    // the first installed embedding model (or a recommended one) becomes the
+    // global default only while none is configured yet.
+    void api.getConfig().then(current => {
+      if ((current.embeddingModel ?? '').trim() !== '') return
+      const candidate = [...ollamaSuggestions.ollamaEmbedding, ...ollamaInstalled.map(m => m.name)]
+        .find(name => /embed|bge|mxbai|e5|gte|nomic/i.test(name))
+      if (candidate !== undefined) void api.setConfig({ embeddingModel: candidate }).catch(() => {})
+    }).catch(() => {})
+  }, [api, ollamaBase, ollamaInstalled, ollamaSuggestions])
 
   // Live Ollama pull progress (polled only while a pull is actually running).
   // The moment a pull leaves the `pulling` state its card clears and, on
@@ -252,6 +270,14 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
     setError(null)
     try {
       await api.pullOllamaModel(model, ollamaBase)
+      // Pulling from an Ollama server makes it the global embedding default
+      // (provider + URL), so new bases inherit it instead of reconfiguring.
+      persistOllamaDefault()
+      // If the pulled model is an embedding model, also set it as the global
+      // embedding-model default.
+      if (ollamaSuggestions.ollamaEmbedding.includes(model) || /embed|bge|mxbai|e5|gte|nomic/i.test(model)) {
+        void api.setConfig({ embeddingModel: model }).catch(() => {})
+      }
       setPullingModels(prev => prev.some(p => p.model === model)
         ? prev
         : [...prev, { model, status: 'pulling', progress: 0, message: '' }])
@@ -264,7 +290,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
       setError(`${err instanceof Error ? err.message : String(err)} ${t('ollamaNeedInstall')}`)
       setOllamaBusy(false)
     }
-  }, [api, ollamaModel, ollamaBase, t])
+  }, [api, ollamaModel, ollamaBase, ollamaSuggestions, persistOllamaDefault, t])
 
   const cancelOllama = useCallback(async (model: string): Promise<void> => {
     try {
@@ -559,7 +585,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
             value={ollamaBase}
             onChange={(e) => setOllamaBase(e.target.value)}
           />
-          <button className="kb-btn" style={style.button} disabled={ollamaBusy} onClick={() => void refreshOllamaTags()}>
+          <button className="kb-btn" style={style.button} disabled={ollamaBusy} onClick={() => { persistOllamaDefault(); void refreshOllamaTags() }}>
             <IconRefresh size={13} />{t('ollamaRefresh')}
           </button>
         </div>

--- a/src/ui/client/LocalModelsSection.tsx
+++ b/src/ui/client/LocalModelsSection.tsx
@@ -181,24 +181,6 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
     }
   }, [api, ollamaBase, t])
 
-  // Make the Ollama server used here the global embedding default, so new
-  // bases inherit it (per-base settings only override it). Non-fatal on
-  // error — model management must keep working even if persistence fails.
-  const persistOllamaDefault = useCallback((): void => {
-    const base = ollamaBase.trim()
-    if (base === '') return
-    void api.setConfig({ embeddingProvider: 'ollama', embeddingBaseUrl: base }).catch(() => {})
-    // Also default the embedding model so a fresh base embeds out of the box:
-    // the first installed embedding model (or a recommended one) becomes the
-    // global default only while none is configured yet.
-    void api.getConfig().then(current => {
-      if ((current.embeddingModel ?? '').trim() !== '') return
-      const candidate = [...ollamaSuggestions.ollamaEmbedding, ...ollamaInstalled.map(m => m.name)]
-        .find(name => /embed|bge|mxbai|e5|gte|nomic/i.test(name))
-      if (candidate !== undefined) void api.setConfig({ embeddingModel: candidate }).catch(() => {})
-    }).catch(() => {})
-  }, [api, ollamaBase, ollamaInstalled, ollamaSuggestions])
-
   // Live Ollama pull progress (polled only while a pull is actually running).
   // The moment a pull leaves the `pulling` state its card clears and, on
   // success, an installed-model refresh brings the new model into the list.
@@ -270,14 +252,6 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
     setError(null)
     try {
       await api.pullOllamaModel(model, ollamaBase)
-      // Pulling from an Ollama server makes it the global embedding default
-      // (provider + URL), so new bases inherit it instead of reconfiguring.
-      persistOllamaDefault()
-      // If the pulled model is an embedding model, also set it as the global
-      // embedding-model default.
-      if (ollamaSuggestions.ollamaEmbedding.includes(model) || /embed|bge|mxbai|e5|gte|nomic/i.test(model)) {
-        void api.setConfig({ embeddingModel: model }).catch(() => {})
-      }
       setPullingModels(prev => prev.some(p => p.model === model)
         ? prev
         : [...prev, { model, status: 'pulling', progress: 0, message: '' }])
@@ -290,7 +264,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
       setError(`${err instanceof Error ? err.message : String(err)} ${t('ollamaNeedInstall')}`)
       setOllamaBusy(false)
     }
-  }, [api, ollamaModel, ollamaBase, ollamaSuggestions, persistOllamaDefault, t])
+  }, [api, ollamaModel, ollamaBase, t])
 
   const cancelOllama = useCallback(async (model: string): Promise<void> => {
     try {
@@ -585,7 +559,7 @@ export function LocalModelsSection(props: LocalModelsSectionProps): JSX.Element 
             value={ollamaBase}
             onChange={(e) => setOllamaBase(e.target.value)}
           />
-          <button className="kb-btn" style={style.button} disabled={ollamaBusy} onClick={() => { persistOllamaDefault(); void refreshOllamaTags() }}>
+          <button className="kb-btn" style={style.button} disabled={ollamaBusy} onClick={() => void refreshOllamaTags()}>
             <IconRefresh size={13} />{t('ollamaRefresh')}
           </button>
         </div>

--- a/src/ui/client/api.ts
+++ b/src/ui/client/api.ts
@@ -42,16 +42,29 @@ export interface BaseConfig {
   resumeInterruptedOnStartup?: boolean
 }
 
+/** One origin line for a base: where its content came from (shown under the
+ *  base name in the detail header — path for directories/files, link for URLs,
+ *  "node" for manually added text). */
+export interface BaseSourceInfo {
+  kind: 'text' | 'file' | 'url' | 'directory'
+  /** Directory path / file name / URL / 'node'. */
+  text: string
+}
+
 export interface BaseSummary {
   id: string
   name: string
   description: string
   group?: string
   documentCount: number
+  /** Documents with a persisted raw source copy (actually imported & stored). */
+  storedDocCount: number
   chunkCount: number
   charCount: number
   tokenCount: number
   config?: BaseConfig
+  /** Top-level sources of the base's content, for display (bounded). */
+  sourceInfo?: BaseSourceInfo[]
   createdAt: number
   updatedAt: number
 }
@@ -232,6 +245,8 @@ export interface RerankStatus {
 export interface BaseStats {
   baseId?: string
   documentCount: number
+  /** Documents with a persisted raw source copy (actually imported & stored). */
+  storedDocCount: number
   chunkCount: number
   charCount: number
   tokenCount: number
@@ -275,14 +290,16 @@ interface Envelope<T> {
 }
 
 export class KnowledgeApi {
-  private async call<T>(method: string, path: string, body?: unknown): Promise<T> {
+  private async call<T>(method: string, path: string, body?: unknown, timeoutMs = 60_000): Promise<T> {
     const response = await fetch(`/knowledge${path}`, {
       method,
       headers: body !== undefined ? { 'content-type': 'application/json' } : undefined,
       body: body !== undefined ? JSON.stringify(body) : undefined,
       // A hung host must not pin the panel's busy state forever: fail the
-      // call with a clear error instead of an indefinite spinner.
-      signal: AbortSignal.timeout(60_000),
+      // call with a clear error instead of an indefinite spinner. Long-running
+      // jobs (reindex of a whole base) pass a larger budget so a slow sweep is
+      // not cut short while the server is still working.
+      signal: AbortSignal.timeout(timeoutMs),
     })
     let envelope: Envelope<T>
     try {
@@ -517,6 +534,16 @@ export class KnowledgeApi {
     return this.call('POST', `/bases/${encodeURIComponent(baseId)}/import-directory-tree`, { baseId, path })
   }
 
+  /** Import a local directory or single file by its absolute path (validated server-side). */
+  importFromPath(baseId: string, path: string): Promise<{ kind: 'directory' | 'file'; imported: number }> {
+    return this.call('POST', `/bases/${encodeURIComponent(baseId)}/import-path`, { baseId, path })
+  }
+
+  /** Repoint the base's source path (validated server-side). */
+  setBaseSourcePath(baseId: string, path: string): Promise<{ set: number }> {
+    return this.call('POST', `/bases/${encodeURIComponent(baseId)}/source-path`, { baseId, path })
+  }
+
   getDirectoryImport(jobId: string): Promise<DirectoryImportStatus> {
     return this.call('GET', `/import-directory/${encodeURIComponent(jobId)}`)
   }
@@ -541,7 +568,7 @@ export class KnowledgeApi {
   }
 
   reindexDocument(documentId: string): Promise<{ id: string; chunkCount: number }> {
-    return this.call('POST', `/documents/${encodeURIComponent(documentId)}/reindex`)
+    return this.call('POST', `/documents/${encodeURIComponent(documentId)}/reindex`, undefined, 30 * 60_000)
   }
 
   refreshUrlDocument(documentId: string): Promise<{ changed: boolean; title: string; chunkCount: number }> {
@@ -549,7 +576,7 @@ export class KnowledgeApi {
   }
 
   reindexDocuments(ids: string[]): Promise<{ reindexed: number; skipped: number }> {
-    return this.call('POST', '/documents/reindex', { ids })
+    return this.call('POST', '/documents/reindex', { ids }, 30 * 60_000)
   }
 
   deleteDocument(id: string): Promise<{ deleted: boolean }> {

--- a/src/ui/client/api.ts
+++ b/src/ui/client/api.ts
@@ -46,9 +46,13 @@ export interface BaseConfig {
  *  base name in the detail header — path for directories/files, link for URLs,
  *  "node" for manually added text). */
 export interface BaseSourceInfo {
+  /** Top-level document/container that owns this source. */
+  sourceId: string
   kind: 'text' | 'file' | 'url' | 'directory'
   /** Directory path / file name / URL / 'node'. */
   text: string
+  /** Absolute tracked path when this source can be repointed. */
+  sourcePath?: string
 }
 
 export interface BaseSummary {
@@ -535,13 +539,13 @@ export class KnowledgeApi {
   }
 
   /** Import a local directory or single file by its absolute path (validated server-side). */
-  importFromPath(baseId: string, path: string): Promise<{ kind: 'directory' | 'file'; imported: number }> {
-    return this.call('POST', `/bases/${encodeURIComponent(baseId)}/import-path`, { baseId, path })
+  importFromPath(baseId: string, path: string): Promise<{ kind: 'directory' | 'file'; imported: number; errors: Array<{ file: string; error: string }> }> {
+    return this.call('POST', `/bases/${encodeURIComponent(baseId)}/import-path`, { baseId, path }, 30 * 60_000)
   }
 
   /** Repoint the base's source path (validated server-side). */
-  setBaseSourcePath(baseId: string, path: string): Promise<{ set: number }> {
-    return this.call('POST', `/bases/${encodeURIComponent(baseId)}/source-path`, { baseId, path })
+  setBaseSourcePath(baseId: string, sourceId: string, path: string): Promise<{ set: number }> {
+    return this.call('POST', `/bases/${encodeURIComponent(baseId)}/source-path`, { baseId, sourceId, path })
   }
 
   getDirectoryImport(jobId: string): Promise<DirectoryImportStatus> {

--- a/src/ui/client/dialogs.tsx
+++ b/src/ui/client/dialogs.tsx
@@ -20,7 +20,7 @@ export interface Toast {
   text: string
 }
 
-export function Toasts(props: { toasts: readonly Toast[] }): JSX.Element | null {
+export function Toasts(props: { toasts: readonly Toast[]; onDismiss?: (id: number) => void }): JSX.Element | null {
   if (props.toasts.length === 0) return null
   return (
     <div style={style.toastStack}>
@@ -33,7 +33,10 @@ export function Toasts(props: { toasts: readonly Toast[] }): JSX.Element | null 
               : toast.kind === 'warning'
                 ? <IconX size={14} color="#f5a524" />
                 : null}
-          <span>{toast.text}</span>
+          <span style={{ userSelect: 'text', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{toast.text}</span>
+          <button style={style.toastClose} onClick={() => props.onDismiss?.(toast.id)} aria-label="close">
+            <IconX size={12} color={C.muted} />
+          </button>
         </div>
       ))}
     </div>
@@ -77,7 +80,7 @@ export function ConfirmDialog(props: {
       <p style={{ fontSize: 13, margin: '0 0 16px', lineHeight: 1.6 }}>{props.message}</p>
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>✕</button>
-        <button style={style.primaryDanger} onClick={props.onConfirm} disabled={props.busy === true}>{props.confirmLabel}</button>
+        <button className="kb-danger-primary" style={style.primaryDanger} onClick={props.onConfirm} disabled={props.busy === true}>{props.confirmLabel}</button>
       </div>
     </Modal>
   )
@@ -116,7 +119,7 @@ export function PromptDialog(props: {
       </div>
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>✕</button>
-        <button style={style.primary} disabled={submitting || value.trim().length === 0} onClick={submit}>OK</button>
+        <button className="kb-primary" style={style.primary} disabled={submitting || value.trim().length === 0} onClick={submit}>OK</button>
       </div>
     </Modal>
   )
@@ -157,7 +160,7 @@ export function TextDocumentDialog(props: {
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>{props.t('cancel')}</button>
         <button
-          style={style.primary}
+          className="kb-primary" style={style.primary}
           disabled={props.busy === true || title.trim().length === 0 || content.trim().length === 0}
           onClick={() => props.onCreate(title.trim(), content)}
         >
@@ -200,11 +203,17 @@ export function RestoreBaseDialog(props: {
       </div>
       <div style={style.field}>
         <label style={style.label}>{props.t('embeddingModel')}</label>
-        <select style={style.input} value={provider} onChange={(e) => setProvider(e.target.value as typeof provider)}>
+        <select style={style.input} value={provider} onChange={(e) => {
+          const next = e.target.value as typeof provider
+          // Auto-fill the well-known local Ollama endpoint when the user
+          // switches to Ollama, so the URL is not retyped by hand.
+          if (next === 'ollama' && baseUrl.trim() === '') setBaseUrl('http://127.0.0.1:11434')
+          setProvider(next)
+        }}>
           <option value="none">{props.t('restoreKeepModel')}</option>
-          <option value="openai">OpenAI 兼容</option>
+          <option value="openai">{props.t('providerOpenAI')}</option>
           <option value="ollama">Ollama</option>
-          <option value="local">本地模型</option>
+          <option value="local">{props.t('providerLocal')}</option>
         </select>
       </div>
       {modelChanged && (
@@ -257,7 +266,7 @@ export function RestoreBaseDialog(props: {
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>{props.t('cancel')}</button>
         <button
-          style={style.primary}
+          className="kb-primary" style={style.primary}
           disabled={props.busy === true || name.trim().length === 0 || (modelChanged && model.trim().length === 0)}
           onClick={() => props.onRestore(
             name.trim(),
@@ -308,7 +317,7 @@ export function CreateBaseDialog(props: {
       <div style={{ ...style.actionsRow, justifyContent: 'flex-end' }}>
         <button style={style.button} onClick={props.onClose}>{props.t('cancel')}</button>
         <button
-          style={style.primary}
+          className="kb-primary" style={style.primary}
           disabled={props.busy === true || name.trim().length === 0}
           onClick={() => props.onCreate(name.trim(), description.trim(), group.trim() === '' ? undefined : group.trim())}
         >

--- a/src/ui/client/locales.ts
+++ b/src/ui/client/locales.ts
@@ -111,6 +111,10 @@ export type KnowledgeKey =
   | 'batchSize'
   | 'stats'
   | 'statsDocs'
+  | 'statsSourceDocs'
+  | 'statsStoredDocs'
+  | 'statsSourceDocsTitle'
+  | 'statsStoredDocsTitle'
   | 'statsChunks'
   | 'statsChars'
   | 'statsTokens'
@@ -125,6 +129,10 @@ export type KnowledgeKey =
   | 'docCount'
   | 'chunkCount'
   | 'tabDir'
+  | 'tabPath'
+  | 'pathDesc'
+  | 'sourcePathEdit'
+  | 'sourcePathPrompt'
   | 'dirPlaceholder'
   | 'importDirButton'
   | 'conflictTitle'
@@ -299,6 +307,18 @@ export type KnowledgeKey =
   | 'kbScopeHint'
   | 'dragResize'
   | 'loadMoreChunks'
+  | 'timeJustNow'
+  | 'timeMinutes'
+  | 'timeHours'
+  | 'timeDays'
+  | 'cacheDirPickUnavailable'
+  | 'cacheDirMigrated'
+  | 'mineruOption'
+  | 'mineruHostPlaceholder'
+  | 'visionModelPlaceholder'
+  | 'captionBaseUrlOllamaPlaceholder'
+  | 'captionBaseUrlPlaceholder'
+  | 'citationSource'
   | 'error'
 
 /** Bound translate over the knowledge dictionary. */
@@ -402,6 +422,10 @@ export const zh: Record<KnowledgeKey, string> = {
   batchSize: 'embedding 批大小',
   stats: '统计',
   statsDocs: '文档',
+  statsSourceDocs: '来源文档',
+  statsStoredDocs: '已解析文档',
+  statsSourceDocsTitle: '来源中跟踪的项目（文件夹 + 文件）',
+  statsStoredDocsTitle: '实际解析并作为原始副本存储在缓存中的文档',
   statsChunks: '分块',
   statsChars: '字符',
   statsTokens: '≈ Token',
@@ -416,6 +440,10 @@ export const zh: Record<KnowledgeKey, string> = {
   docCount: '个文档',
   chunkCount: '个分块',
   tabDir: '目录',
+  tabPath: '路径',
+  pathDesc: '输入目录或文件的绝对路径',
+  sourcePathEdit: '修改来源路径',
+  sourcePathPrompt: '来源路径',
   dirPlaceholder: '输入本机目录路径，如 D:\\docs\\policy',
   importDirButton: '导入',
   conflictTitle: '存在同名数据源',
@@ -599,6 +627,18 @@ export const zh: Record<KnowledgeKey, string> = {
   kbScopeHint: '留空 = 全部库可用',
   dragResize: '拖动调整宽度',
   loadMoreChunks: '加载更多分块',
+  timeJustNow: '刚刚',
+  timeMinutes: '{n} 分钟前',
+  timeHours: '{n} 小时前',
+  timeDays: '{n} 天前',
+  cacheDirPickUnavailable: '文件夹选择不可用（当前环境无目录选择能力）',
+  cacheDirMigrated: '{count} 个模型目录已迁移到 {to}',
+  mineruOption: 'MinerU（远程，扫描件/复杂版面）',
+  mineruHostPlaceholder: 'API Host（默认 https://mineru.net）',
+  visionModelPlaceholder: '视觉模型（如 qwen-vl-plus、gpt-4o-mini）',
+  captionBaseUrlOllamaPlaceholder: 'Ollama 地址（默认 http://127.0.0.1:11434）',
+  captionBaseUrlPlaceholder: 'API 地址（留空用嵌入模型地址）',
+  citationSource: '（知识库 {id}）',
   error: '出错了',
 }
 
@@ -700,6 +740,10 @@ export const en: Record<KnowledgeKey, string> = {
   batchSize: 'Embedding batch size',
   stats: 'Stats',
   statsDocs: 'docs',
+  statsSourceDocs: 'source docs',
+  statsStoredDocs: 'parsed docs',
+  statsSourceDocsTitle: 'Items tracked from the source (folders + files)',
+  statsStoredDocsTitle: 'Documents actually parsed and stored as raw copies in the cache',
   statsChunks: 'chunks',
   statsChars: 'chars',
   statsTokens: '~tokens',
@@ -714,6 +758,10 @@ export const en: Record<KnowledgeKey, string> = {
   docCount: ' docs',
   chunkCount: ' chunks',
   tabDir: 'Directory',
+  tabPath: 'Path',
+  pathDesc: 'Absolute path to a directory or file',
+  sourcePathEdit: 'Edit source path',
+  sourcePathPrompt: 'Source path',
   dirPlaceholder: 'Enter a local directory path, e.g. D:\\docs\\policy',
   importDirButton: 'Import',
   conflictTitle: 'Same-name source',
@@ -792,7 +840,7 @@ export const en: Record<KnowledgeKey, string> = {
   noOllamaModels: 'No installed Ollama models — pull one in Settings → Local Models',
   selectModelPlaceholder: 'Select a model',
   ollamaUnreachable: 'Cannot reach Ollama (check the address or whether it is running)',
-  embeddingSwitchWarning: '⚠ Switching the embedding model invalidates this base\'s stored vectors, so the save will be refused — rebuild via 重建知识库 with the new model instead (or empty the base first)',
+  embeddingSwitchWarning: '⚠ Switching the embedding model invalidates this base\'s stored vectors, so the save will be refused — rebuild via \u201cRebuild base\u201d with the new model instead (or empty the base first)',
   staleModelSuffix: ' (not installed)',
   embeddingModelMissingHint: 'The embedding provider is the local model, which is not downloaded yet — imported content cannot be vectorized for retrieval. Download the embedding model (~585MB) in Settings → Local Models first.',
   localModelStatusLabel: 'Local embedding model',
@@ -897,5 +945,17 @@ export const en: Record<KnowledgeKey, string> = {
   kbScopeHint: 'Empty = all bases',
   dragResize: 'Drag to resize',
   loadMoreChunks: 'Load more chunks',
+  timeJustNow: 'just now',
+  timeMinutes: '{n} min ago',
+  timeHours: '{n} h ago',
+  timeDays: '{n} d ago',
+  cacheDirPickUnavailable: 'Folder picking is unavailable (this environment has no directory picker)',
+  cacheDirMigrated: '{count} model director(y/ies) moved to {to}',
+  mineruOption: 'MinerU (remote, scans/complex layouts)',
+  mineruHostPlaceholder: 'API Host (default https://mineru.net)',
+  visionModelPlaceholder: 'Vision model (e.g. qwen-vl-plus, gpt-4o-mini)',
+  captionBaseUrlOllamaPlaceholder: 'Ollama URL (default http://127.0.0.1:11434)',
+  captionBaseUrlPlaceholder: 'API URL (leave empty to use the embedding model URL)',
+  citationSource: ' (KB {id})',
   error: 'Error',
 }

--- a/src/ui/client/locales.ts
+++ b/src/ui/client/locales.ts
@@ -133,6 +133,7 @@ export type KnowledgeKey =
   | 'pathDesc'
   | 'sourcePathEdit'
   | 'sourcePathPrompt'
+  | 'pathImportPartial'
   | 'dirPlaceholder'
   | 'importDirButton'
   | 'conflictTitle'
@@ -422,7 +423,7 @@ export const zh: Record<KnowledgeKey, string> = {
   batchSize: 'embedding 批大小',
   stats: '统计',
   statsDocs: '文档',
-  statsSourceDocs: '来源文档',
+  statsSourceDocs: '来源项',
   statsStoredDocs: '已解析文档',
   statsSourceDocsTitle: '来源中跟踪的项目（文件夹 + 文件）',
   statsStoredDocsTitle: '实际解析并作为原始副本存储在缓存中的文档',
@@ -444,6 +445,7 @@ export const zh: Record<KnowledgeKey, string> = {
   pathDesc: '输入目录或文件的绝对路径',
   sourcePathEdit: '修改来源路径',
   sourcePathPrompt: '来源路径',
+  pathImportPartial: '导入完成：成功 {count}，失败 {errors}',
   dirPlaceholder: '输入本机目录路径，如 D:\\docs\\policy',
   importDirButton: '导入',
   conflictTitle: '存在同名数据源',
@@ -632,7 +634,7 @@ export const zh: Record<KnowledgeKey, string> = {
   timeHours: '{n} 小时前',
   timeDays: '{n} 天前',
   cacheDirPickUnavailable: '文件夹选择不可用（当前环境无目录选择能力）',
-  cacheDirMigrated: '{count} 个模型目录已迁移到 {to}',
+  cacheDirMigrated: '模型缓存已迁移到 {to}（移动条目：{count}）',
   mineruOption: 'MinerU（远程，扫描件/复杂版面）',
   mineruHostPlaceholder: 'API Host（默认 https://mineru.net）',
   visionModelPlaceholder: '视觉模型（如 qwen-vl-plus、gpt-4o-mini）',
@@ -740,7 +742,7 @@ export const en: Record<KnowledgeKey, string> = {
   batchSize: 'Embedding batch size',
   stats: 'Stats',
   statsDocs: 'docs',
-  statsSourceDocs: 'source docs',
+  statsSourceDocs: 'source items',
   statsStoredDocs: 'parsed docs',
   statsSourceDocsTitle: 'Items tracked from the source (folders + files)',
   statsStoredDocsTitle: 'Documents actually parsed and stored as raw copies in the cache',
@@ -762,6 +764,7 @@ export const en: Record<KnowledgeKey, string> = {
   pathDesc: 'Absolute path to a directory or file',
   sourcePathEdit: 'Edit source path',
   sourcePathPrompt: 'Source path',
+  pathImportPartial: 'Import finished: {count} succeeded, {errors} failed',
   dirPlaceholder: 'Enter a local directory path, e.g. D:\\docs\\policy',
   importDirButton: 'Import',
   conflictTitle: 'Same-name source',
@@ -950,7 +953,7 @@ export const en: Record<KnowledgeKey, string> = {
   timeHours: '{n} h ago',
   timeDays: '{n} d ago',
   cacheDirPickUnavailable: 'Folder picking is unavailable (this environment has no directory picker)',
-  cacheDirMigrated: '{count} model director(y/ies) moved to {to}',
+  cacheDirMigrated: 'Model cache migrated to {to} ({count} entries moved)',
   mineruOption: 'MinerU (remote, scans/complex layouts)',
   mineruHostPlaceholder: 'API Host (default https://mineru.net)',
   visionModelPlaceholder: 'Vision model (e.g. qwen-vl-plus, gpt-4o-mini)',

--- a/src/ui/client/popover-placement.ts
+++ b/src/ui/client/popover-placement.ts
@@ -1,0 +1,71 @@
+/** Pure viewport placement helpers shared by the portal popover and tests. */
+
+export interface ViewportSize {
+  width: number
+  height: number
+}
+
+export interface BoxSize {
+  width: number
+  height: number
+}
+
+export interface RectEdges {
+  top: number
+  right: number
+  bottom: number
+  left: number
+}
+
+export interface ViewportPosition {
+  top: number
+  left: number
+}
+
+const VIEWPORT_MARGIN = 8
+const MENU_GAP = 4
+
+/** Place a root menu below/above its trigger and clamp both axes. */
+export function placePopover(
+  trigger: RectEdges,
+  menu: BoxSize,
+  viewport: ViewportSize,
+  align: 'start' | 'end' = 'start',
+): ViewportPosition {
+  const maxLeft = Math.max(VIEWPORT_MARGIN, viewport.width - menu.width - VIEWPORT_MARGIN)
+  const preferredLeft = align === 'end' ? trigger.right - menu.width : trigger.left
+  const left = clamp(preferredLeft, VIEWPORT_MARGIN, maxLeft)
+
+  const below = trigger.bottom + MENU_GAP
+  const above = trigger.top - menu.height - MENU_GAP
+  const fitsBelow = below + menu.height <= viewport.height - VIEWPORT_MARGIN
+  const fitsAbove = above >= VIEWPORT_MARGIN
+  const preferredTop = fitsBelow || !fitsAbove ? below : above
+  const maxTop = Math.max(VIEWPORT_MARGIN, viewport.height - menu.height - VIEWPORT_MARGIN)
+  return { top: clamp(preferredTop, VIEWPORT_MARGIN, maxTop), left }
+}
+
+/** Place a submenu beside its parent row, flipping left near the right edge. */
+export function placeSubmenu(
+  parent: RectEdges,
+  menu: BoxSize,
+  viewport: ViewportSize,
+): ViewportPosition {
+  const maxLeft = Math.max(VIEWPORT_MARGIN, viewport.width - menu.width - VIEWPORT_MARGIN)
+  const right = parent.right + MENU_GAP
+  const left = parent.left - menu.width - MENU_GAP
+  const preferredLeft = right + menu.width <= viewport.width - VIEWPORT_MARGIN
+    ? right
+    : left >= VIEWPORT_MARGIN
+      ? left
+      : right
+  const maxTop = Math.max(VIEWPORT_MARGIN, viewport.height - menu.height - VIEWPORT_MARGIN)
+  return {
+    top: clamp(parent.top, VIEWPORT_MARGIN, maxTop),
+    left: clamp(preferredLeft, VIEWPORT_MARGIN, maxLeft),
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}

--- a/src/ui/client/popover.tsx
+++ b/src/ui/client/popover.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type { ReactNode } from 'react'
 import { style } from './theme.js'
 
@@ -26,38 +27,107 @@ export function PopoverMenu(props: {
 }): JSX.Element {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
+  // The menu renders in a body-level portal, OUTSIDE ref — track it too so
+  // clicks on menu items are not treated as outside-clicks (otherwise the
+  // mousedown dismissal unmounts the menu before the item's click fires and
+  // every menu action silently dies).
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [pos, setPos] = useState<{ top: number; left?: number; right?: number } | null>(null)
 
   useEffect(() => {
     if (!open) return
     const onDocumentClick = (event: MouseEvent): void => {
-      if (ref.current !== null && !ref.current.contains(event.target as Node)) setOpen(false)
+      const target = event.target as Node
+      if (ref.current !== null && ref.current.contains(target)) return
+      if (menuRef.current !== null && menuRef.current.contains(target)) return
+      setOpen(false)
     }
+    const onScroll = (): void => setOpen(false)
+    const onResize = (): void => setOpen(false)
     document.addEventListener('mousedown', onDocumentClick)
-    return () => document.removeEventListener('mousedown', onDocumentClick)
+    window.addEventListener('scroll', onScroll, true)
+    window.addEventListener('resize', onResize)
+    return () => {
+      document.removeEventListener('mousedown', onDocumentClick)
+      window.removeEventListener('scroll', onScroll, true)
+      window.removeEventListener('resize', onResize)
+    }
   }, [open])
+
+  const toggle = (): void => {
+    const next = !open
+    setOpen(next)
+    if (next && ref.current !== null) {
+      const rect = ref.current.getBoundingClientRect()
+      // Open below the trigger; flip above when there isn't enough room below
+      // (menu is rendered in a body-level portal so it must stay in the viewport).
+      const est = estimateMenuHeight(props.entries)
+      const below = window.innerHeight - rect.bottom - 8
+      const above = rect.top - 8
+      const top = (below >= est || below >= above) ? rect.bottom + 4 : Math.max(8, rect.top - est - 4)
+      setPos({
+        top,
+        left: props.align === 'end' ? undefined : rect.left,
+        right: props.align === 'end' ? window.innerWidth - rect.right : undefined,
+      })
+    }
+  }
 
   return (
     <div ref={ref} style={{ position: 'relative', display: 'inline-flex' }}>
       <span
         style={{ display: 'inline-flex' }}
-        onClick={(e) => { e.stopPropagation(); setOpen(v => !v) }}
+        onClick={(e) => { e.stopPropagation(); toggle() }}
       >
         {props.trigger}
       </span>
-      {open && (
+      {open && pos !== null && createPortal(
         <div
-          style={{ ...style.menu, top: 'calc(100% + 4px)', ...(props.align === 'end' ? { right: 0 } : { left: 0 }) }}
+          ref={menuRef}
+          style={{
+            ...style.menu,
+            position: 'fixed',
+            top: pos.top,
+            left: pos.left,
+            right: pos.right,
+            // Body-level portal: sit above the whole panel (zIndex 300) so the
+            // menu can never be buried by list rows or clipped by a scrollable
+            // sidebar's overflow.
+            zIndex: 1000,
+          }}
           onClick={(e) => e.stopPropagation()}
         >
           <MenuItems entries={props.entries} onCloseAll={() => setOpen(false)} />
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   )
 }
 
+/** Rough menu height for deciding whether to open below vs above the trigger. */
+function estimateMenuHeight(entries: readonly MenuEntry[]): number {
+  let h = 8 // menu vertical padding
+  for (const e of entries) h += e.label === undefined ? 9 : 36 // separator vs item
+  return h
+}
+
 function MenuItems(props: { entries: readonly MenuEntry[]; onCloseAll: () => void }): JSX.Element {
   const [openSub, setOpenSub] = useState<string | null>(null)
+  const closeTimer = useRef<number | null>(null)
+  const cancelClose = (): void => {
+    if (closeTimer.current !== null) {
+      window.clearTimeout(closeTimer.current)
+      closeTimer.current = null
+    }
+  }
+  const scheduleClose = (): void => {
+    cancelClose()
+    closeTimer.current = window.setTimeout(() => setOpenSub(null), 150)
+  }
+  useEffect(() => () => {
+    if (closeTimer.current !== null) window.clearTimeout(closeTimer.current)
+  }, [])
   return (
     <>
       {props.entries.map(entry =>
@@ -65,11 +135,11 @@ function MenuItems(props: { entries: readonly MenuEntry[]; onCloseAll: () => voi
           ? <div key={entry.key} style={style.menuSeparator} />
           : (
               <div key={entry.key} style={{ position: 'relative' }}
-                onMouseEnter={() => entry.children !== undefined && setOpenSub(entry.key)}
-                onMouseLeave={() => { if (openSub === entry.key) setOpenSub(null) }}
+                onMouseEnter={() => { if (entry.children !== undefined) { cancelClose(); setOpenSub(entry.key) } }}
+                onMouseLeave={() => { if (openSub === entry.key) scheduleClose() }}
               >
                 <button
-                  className="kb-row"
+                  className="kb-row kb-menuitem"
                   style={{ ...style.menuItem, ...(entry.danger === true ? style.menuItemDanger : {}) }}
                   onClick={() => {
                     if (entry.children !== undefined) {
@@ -87,10 +157,13 @@ function MenuItems(props: { entries: readonly MenuEntry[]; onCloseAll: () => voi
                   {entry.children !== undefined && <span style={{ color: 'inherit', opacity: 0.55, fontSize: 10 }}>▸</span>}
                 </button>
                 {entry.children !== undefined && openSub === entry.key && (
-                  <div style={{ ...style.menu, top: -4, left: 'calc(100% + 4px)', position: 'absolute' }}>
+                  <div style={{ ...style.menu, top: 'calc(100% + 4px)', left: 0, position: 'absolute' }}
+                    onMouseEnter={cancelClose}
+                    onMouseLeave={scheduleClose}
+                  >
                     <MenuItems
                       entries={entry.children}
-                      onCloseAll={() => { setOpenSub(null); props.onCloseAll() }}
+                      onCloseAll={() => { cancelClose(); setOpenSub(null); props.onCloseAll() }}
                     />
                   </div>
                 )}

--- a/src/ui/client/popover.tsx
+++ b/src/ui/client/popover.tsx
@@ -5,10 +5,14 @@
  * @module dsh-knowledge/client/popover
  */
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { ReactNode } from 'react'
+import { placePopover, placeSubmenu } from './popover-placement.js'
+import type { ViewportPosition } from './popover-placement.js'
 import { style } from './theme.js'
+
+const MENU_WIDTH = 220
 
 export interface MenuEntry {
   key: string
@@ -32,7 +36,7 @@ export function PopoverMenu(props: {
   // mousedown dismissal unmounts the menu before the item's click fires and
   // every menu action silently dies).
   const menuRef = useRef<HTMLDivElement>(null)
-  const [pos, setPos] = useState<{ top: number; left?: number; right?: number } | null>(null)
+  const [pos, setPos] = useState<ViewportPosition | null>(null)
 
   useEffect(() => {
     if (!open) return
@@ -54,22 +58,31 @@ export function PopoverMenu(props: {
     }
   }, [open])
 
+  // Correct the initial estimate with the rendered menu's actual dimensions.
+  useLayoutEffect(() => {
+    if (!open || ref.current === null || menuRef.current === null) return
+    const trigger = ref.current.getBoundingClientRect()
+    const menu = menuRef.current.getBoundingClientRect()
+    const next = placePopover(
+      trigger,
+      { width: menu.width, height: menu.height },
+      { width: window.innerWidth, height: window.innerHeight },
+      props.align,
+    )
+    setPos(current => current?.top === next.top && current.left === next.left ? current : next)
+  }, [open, props.align, props.entries])
+
   const toggle = (): void => {
     const next = !open
     setOpen(next)
     if (next && ref.current !== null) {
       const rect = ref.current.getBoundingClientRect()
-      // Open below the trigger; flip above when there isn't enough room below
-      // (menu is rendered in a body-level portal so it must stay in the viewport).
-      const est = estimateMenuHeight(props.entries)
-      const below = window.innerHeight - rect.bottom - 8
-      const above = rect.top - 8
-      const top = (below >= est || below >= above) ? rect.bottom + 4 : Math.max(8, rect.top - est - 4)
-      setPos({
-        top,
-        left: props.align === 'end' ? undefined : rect.left,
-        right: props.align === 'end' ? window.innerWidth - rect.right : undefined,
-      })
+      setPos(placePopover(
+        rect,
+        { width: MENU_WIDTH, height: estimateMenuHeight(props.entries) },
+        { width: window.innerWidth, height: window.innerHeight },
+        props.align,
+      ))
     }
   }
 
@@ -89,7 +102,8 @@ export function PopoverMenu(props: {
             position: 'fixed',
             top: pos.top,
             left: pos.left,
-            right: pos.right,
+            width: MENU_WIDTH,
+            maxWidth: 'calc(100vw - 16px)',
             // Body-level portal: sit above the whole panel (zIndex 300) so the
             // menu can never be buried by list rows or clipped by a scrollable
             // sidebar's overflow.
@@ -113,7 +127,7 @@ function estimateMenuHeight(entries: readonly MenuEntry[]): number {
 }
 
 function MenuItems(props: { entries: readonly MenuEntry[]; onCloseAll: () => void }): JSX.Element {
-  const [openSub, setOpenSub] = useState<string | null>(null)
+  const [openSub, setOpenSub] = useState<{ key: string; position: ViewportPosition } | null>(null)
   const closeTimer = useRef<number | null>(null)
   const cancelClose = (): void => {
     if (closeTimer.current !== null) {
@@ -128,6 +142,18 @@ function MenuItems(props: { entries: readonly MenuEntry[]; onCloseAll: () => voi
   useEffect(() => () => {
     if (closeTimer.current !== null) window.clearTimeout(closeTimer.current)
   }, [])
+  const openChildren = (entry: MenuEntry, element: HTMLElement): void => {
+    if (entry.children === undefined) return
+    const rect = element.getBoundingClientRect()
+    setOpenSub({
+      key: entry.key,
+      position: placeSubmenu(
+        rect,
+        { width: MENU_WIDTH, height: estimateMenuHeight(entry.children) },
+        { width: window.innerWidth, height: window.innerHeight },
+      ),
+    })
+  }
   return (
     <>
       {props.entries.map(entry =>
@@ -135,15 +161,16 @@ function MenuItems(props: { entries: readonly MenuEntry[]; onCloseAll: () => voi
           ? <div key={entry.key} style={style.menuSeparator} />
           : (
               <div key={entry.key} style={{ position: 'relative' }}
-                onMouseEnter={() => { if (entry.children !== undefined) { cancelClose(); setOpenSub(entry.key) } }}
-                onMouseLeave={() => { if (openSub === entry.key) scheduleClose() }}
+                onMouseEnter={(event) => { if (entry.children !== undefined) { cancelClose(); openChildren(entry, event.currentTarget) } }}
+                onMouseLeave={() => { if (openSub?.key === entry.key) scheduleClose() }}
               >
                 <button
                   className="kb-row kb-menuitem"
                   style={{ ...style.menuItem, ...(entry.danger === true ? style.menuItemDanger : {}) }}
-                  onClick={() => {
+                  onClick={(event) => {
                     if (entry.children !== undefined) {
-                      setOpenSub(openSub === entry.key ? null : entry.key)
+                      if (openSub?.key === entry.key) setOpenSub(null)
+                      else openChildren(entry, event.currentTarget.parentElement ?? event.currentTarget)
                       return
                     }
                     props.onCloseAll()
@@ -156,8 +183,16 @@ function MenuItems(props: { entries: readonly MenuEntry[]; onCloseAll: () => voi
                   </span>
                   {entry.children !== undefined && <span style={{ color: 'inherit', opacity: 0.55, fontSize: 10 }}>▸</span>}
                 </button>
-                {entry.children !== undefined && openSub === entry.key && (
-                  <div style={{ ...style.menu, top: 'calc(100% + 4px)', left: 0, position: 'absolute' }}
+                {entry.children !== undefined && openSub?.key === entry.key && (
+                  <div style={{
+                    ...style.menu,
+                    position: 'fixed',
+                    top: openSub.position.top,
+                    left: openSub.position.left,
+                    width: MENU_WIDTH,
+                    maxWidth: 'calc(100vw - 16px)',
+                    zIndex: 1001,
+                  }}
                     onMouseEnter={cancelClose}
                     onMouseLeave={scheduleClose}
                   >

--- a/src/ui/client/rag-config.tsx
+++ b/src/ui/client/rag-config.tsx
@@ -185,7 +185,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
         }
       } catch (err) {
         setProbing(false)
-        setSaveError(`${t('dimensionProbeFailed')}：${err instanceof Error ? err.message : String(err)}`)
+        setSaveError(`${t('dimensionProbeFailed')}: ${err instanceof Error ? err.message : String(err)}`)
         return
       }
       setProbing(false)
@@ -223,7 +223,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
             onChange={(e) => patch({ documentProcessorProvider: e.target.value as 'builtin' | 'mineru' })}
           >
             <option value="builtin">{t('processorBuiltin')}</option>
-            <option value="mineru">MinerU（远程，扫描件/复杂版面）</option>
+            <option value="mineru">{t('mineruOption')}</option>
           </select>
           {values.documentProcessorProvider === 'mineru' && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
@@ -236,7 +236,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
               />
               <input
                 style={style.input}
-                placeholder="API Host（默认 https://mineru.net）"
+                placeholder={t('mineruHostPlaceholder')}
                 value={values.mineruApiHost}
                 onChange={(e) => patch({ mineruApiHost: e.target.value })}
               />
@@ -292,7 +292,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
                 ) : (
                   <input
                     style={style.input}
-                    placeholder="视觉模型（如 qwen-vl-plus、gpt-4o-mini）"
+                    placeholder={t('visionModelPlaceholder')}
                     value={values.imageCaptionModel}
                     onChange={(e) => patch({ imageCaptionModel: e.target.value })}
                   />
@@ -300,8 +300,8 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
                 <input
                   style={style.input}
                   placeholder={values.imageCaptionProvider === 'ollama'
-                    ? 'Ollama 地址（默认 http://127.0.0.1:11434）'
-                    : 'API 地址（留空用嵌入模型地址）'}
+                    ? t('captionBaseUrlOllamaPlaceholder')
+                    : t('captionBaseUrlPlaceholder')}
                   value={values.imageCaptionBaseUrl}
                   onChange={(e) => patch({ imageCaptionBaseUrl: e.target.value })}
                 />
@@ -343,7 +343,13 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
                 const next = ollamaEmbeddingModels.includes(values.embeddingModel)
                   ? values.embeddingModel
                   : (ollamaEmbeddingModels[0] ?? '')
-                patch({ embeddingProvider: provider, embeddingModel: next })
+                // Auto-fill the well-known local Ollama endpoint so a user
+                // creating a fresh base does not retype http://127.0.0.1:11434
+                // every time (the model name is already auto-picked).
+                const nextBase = values.embeddingBaseUrl.trim() === ''
+                  ? 'http://127.0.0.1:11434'
+                  : values.embeddingBaseUrl
+                patch({ embeddingProvider: provider, embeddingModel: next, embeddingBaseUrl: nextBase })
               } else {
                 // openai / none: free-text or none — keep whatever was typed.
                 patch({ embeddingProvider: provider })
@@ -683,7 +689,7 @@ export function RagConfigPanel(props: PanelProps): JSX.Element {
         >
           <IconRefresh size={13} />{t('reset')}
         </button>
-        <button style={style.primary} disabled={!dirty || busy || probing} onClick={() => void save()}>
+        <button className="kb-primary" style={style.primary} disabled={!dirty || busy || probing} onClick={() => void save()}>
           {probing ? t('dimensionProbing') : t('save')}
         </button>
       </div>

--- a/src/ui/client/react-dom.d.ts
+++ b/src/ui/client/react-dom.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Ambient declaration for the external `react-dom` module.
+ * `react-dom` is NOT installed here — the DSH shell injects it into the
+ * frozen client module table at runtime (see build.mjs clientExternal), so
+ * esbuild keeps it external. This declaration gives tsc the one member we
+ * use without pulling in @types/react-dom.
+ */
+declare module 'react-dom' {
+  import type { ReactNode } from 'react'
+  export function createPortal(children: ReactNode, container: Element | DocumentFragment): ReactNode
+}

--- a/src/ui/client/theme.ts
+++ b/src/ui/client/theme.ts
@@ -11,10 +11,17 @@ export const C = {
   surface: 'var(--dsw-alias-bg-layer-1, #ffffff)',
   surface2: 'var(--dsw-alias-bg-layer-2, #f1f2f5)',
   overlay: 'var(--dsw-alias-bg-overlay, #ffffff)',
-  border: 'var(--dsw-alias-border-l1, #e3e5e9)',
-  borderStrong: 'var(--dsw-alias-border-l2, #c7ccd4)',
   text: 'var(--dsw-alias-label-primary, #1f2329)',
-  muted: 'var(--dsw-alias-label-secondary, #8a919c)',
+  // DSH's label-secondary is extremely faint in the light theme (#cfd3d6 on
+  // white ≈ 1.4:1), which makes hint/secondary text visually merge with the
+  // surface. Derive a readable "muted" from the primary label color instead
+  // (≈72% of near-black in light, ≈72% of near-white in dark), so it stays
+  // legible in both DSH themes while still reading as secondary.
+  muted: 'color-mix(in srgb, var(--dsw-alias-label-primary, #1f2329) 72%, transparent)',
+  // DSH's border-l1 is ~6% black / 9% white — too faint to separate panels.
+  // Use the stronger border-l2 / border-l3 tiers for card and control edges.
+  border: 'var(--dsw-alias-border-l2, #c7ccd4)',
+  borderStrong: 'var(--dsw-alias-border-l3, #9aa1ab)',
   accent: 'var(--dsw-alias-brand-primary, #3b6ef6)',
   danger: 'var(--dsw-alias-state-error-primary, #e5484d)',
   success: 'var(--dsw-alias-state-success-primary, #30a46c)',
@@ -29,8 +36,24 @@ export const PANEL_CSS = `
 @keyframes kb-fade-in { from { opacity: 0; transform: translateY(6px) } to { opacity: 1; transform: none } }
 .kb-spinner { animation: kb-spin 0.9s linear infinite }
 .kb-panel-in { animation: kb-fade-in 0.18s ease-out }
+/* Theme-adaptive interaction fills. DSH's own layer tokens are pure white in
+   the light theme and its interactive-bg-hover is only ~6% alpha, so hovers
+   built on them are nearly invisible. Derive hover/active fills from the
+   inverted label-primary token instead: ~9% black-on-white in light, ~9%
+   white-on-dark in dark — clearly visible in both base themes. Declared on
+   body (portal menus and the sidebar action render outside the panel) and
+   re-scoped to the panel root. */
+body, .kb-panel-in {
+  --kb-hover: color-mix(in srgb, var(--dsw-alias-label-primary, #1f2329) 9%, transparent);
+  --kb-active: color-mix(in srgb, var(--dsw-alias-label-primary, #1f2329) 16%, transparent);
+}
 .kb-row { transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease }
-.kb-row:hover { background: var(--dsw-alias-bg-layer-2, #f1f2f5) }
+.kb-row:hover { background: var(--kb-hover) }
+/* Menu items fill on hover/active; the fill rides a CSS variable referenced from
+   the inline background so the class can override the inline style. */
+.kb-menuitem { transition: background 0.15s ease }
+.kb-menuitem:hover { --kb-mibg: var(--kb-hover) }
+.kb-menuitem:active { --kb-mibg: var(--kb-active) }
 .kb-card { transition: border-color 0.15s ease, background 0.15s ease }
 .kb-card:hover { border-color: var(--dsw-alias-border-l2, #c7ccd4) }
 .kb-iconbtn { transition: color 0.15s ease, background 0.15s ease }
@@ -38,15 +61,43 @@ export const PANEL_CSS = `
 /* Buttons styled with style.button get a hover tint like the shell's own
    buttons. The tint rides a CSS variable referenced from the inline
    background, because inline styles outrank plain class rules: on hover the
-   variable flips and the inline background follows it. */
+   variable flips and the inline background follows it. The .kb-panel-in rule
+   covers every panel button even without the kb-btn class (the class is only
+   required for the settings section, which lives outside the panel). */
 .kb-btn { transition: background 0.15s ease, border-color 0.15s ease }
-.kb-btn:hover { --kb-btn-bg: var(--dsw-alias-interactive-bg-hover, #eceef1) }
+.kb-btn:hover { --kb-btn-bg: var(--kb-hover) }
 .kb-btn:disabled:hover { --kb-btn-bg: var(--dsw-alias-bg-layer-1, #ffffff) }
+.kb-panel-in button:hover { --kb-btn-bg: var(--kb-hover) }
+.kb-panel-in button:disabled:hover { --kb-btn-bg: var(--dsw-alias-bg-layer-1, #ffffff) }
 /* Backgrounds live in classes (not inline) so :hover can override them, the
    same way the shell's Settings trigger styles itself. */
 .kb-sidebar-action { background: transparent }
-.kb-sidebar-action:hover { background: var(--dsw-alias-interactive-bg-hover) }
+.kb-sidebar-action:hover { background: var(--kb-hover) }
+.kb-sidebar-action:active { background: var(--kb-active) }
 .kb-dangerbtn:hover { color: var(--dsw-alias-state-error-primary, #e5484d); background: color-mix(in srgb, var(--dsw-alias-state-error-primary, #e5484d) 10%, transparent) }
+/* Primary (accent-filled) buttons: DSH's brand-primary inverts between themes
+   (near-black in light, near-white in dark) and ships a dedicated hover token,
+   so the hover fill follows that token and stays visible in both. */
+.kb-primary { transition: background 0.15s ease, filter 0.15s ease }
+.kb-primary:hover:not(:disabled) { --kb-primary-bg: var(--dsw-alias-button-primary-hover, #43454a) }
+.kb-primary:active:not(:disabled) { filter: brightness(0.94) }
+.kb-primary:disabled { opacity: 0.5; cursor: not-allowed }
+.kb-danger-primary { transition: background 0.15s ease, filter 0.15s ease }
+.kb-danger-primary:hover:not(:disabled) { --kb-danger-bg: color-mix(in srgb, var(--dsw-alias-state-error-primary, #e5484d) 78%, #000) }
+.kb-danger-primary:active:not(:disabled) { filter: brightness(0.94) }
+.kb-danger-primary:disabled { opacity: 0.5; cursor: not-allowed }
+/* Disabled feedback for every panel button. */
+.kb-panel-in button:disabled { opacity: 0.5; cursor: not-allowed }
+/* Visible focus indicators (DSH's business-primary is a blue that reads in
+   both themes, unlike the inverted brand-primary). */
+.kb-panel-in button:focus-visible, .kb-menuitem:focus-visible, .kb-sidebar-action:focus-visible { outline: 2px solid var(--dsw-alias-state-business-primary, #4176e6); outline-offset: 2px }
+.kb-panel-in input:focus, .kb-panel-in select:focus, .kb-panel-in textarea:focus { box-shadow: 0 0 0 2px color-mix(in srgb, var(--dsw-alias-state-business-primary, #4176e6) 35%, transparent) }
+/* Resize sash: an 8px grab strip whose 2px grip lights up on hover so the
+   draggable edge is discoverable (a 5px transparent sliver was impossible to
+   find/click). z-index keeps it above adjacent scrollbars. */
+.kb-sash { position: relative; z-index: 6 }
+.kb-sash::before { content: ''; position: absolute; top: 0; bottom: 0; left: 50%; transform: translateX(-50%); width: 2px; background: transparent; transition: background 0.15s ease }
+.kb-sash:hover::before { background: color-mix(in srgb, var(--dsw-alias-brand-primary, #3b6ef6) 45%, transparent) }
 .kb-scroll::-webkit-scrollbar { width: 8px; height: 8px }
 .kb-scroll::-webkit-scrollbar-thumb { background: var(--dsw-alias-border-l2, #c7ccd4); border-radius: 999px }
 .kb-scroll::-webkit-scrollbar-track { background: transparent }
@@ -95,6 +146,21 @@ export const style = {
   } as CSSProperties,
   baseName: { fontSize: 13, fontWeight: 600 } as CSSProperties,
   baseMeta: { fontSize: 11, color: C.muted, marginTop: 2 } as CSSProperties,
+  baseSourceRow: {
+    display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '4px 14px',
+    marginTop: 6, padding: '5px 10px', borderRadius: 8,
+    background: 'color-mix(in srgb, var(--dsw-alias-label-primary, #1f2329) 6%, transparent)',
+    fontSize: 11, color: C.muted,
+  } as CSSProperties,
+  baseSourceItem: { display: 'inline-flex', alignItems: 'center', gap: 5, minWidth: 0 } as CSSProperties,
+  baseSourceGlyph: {
+    display: 'inline-flex', alignItems: 'center', flexShrink: 0, color: C.accent,
+  } as CSSProperties,
+  baseSourceText: {
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    fontFamily: "'JetBrains Mono', ui-monospace, 'SF Mono', Consolas, monospace",
+  } as CSSProperties,
+  baseSourceEdit: { marginLeft: 'auto', flexShrink: 0 } as CSSProperties,
   main: { flex: 1, minWidth: 0, overflowY: 'auto', padding: 18, display: 'flex', flexDirection: 'column', gap: 14 } as CSSProperties,
   card: { border: `1px solid ${C.border}`, borderRadius: 12, background: C.surface, padding: 14, position: 'relative' } as CSSProperties,
   cardTitle: { fontSize: 13, fontWeight: 600, margin: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between' } as CSSProperties,
@@ -104,12 +170,16 @@ export const style = {
   } as CSSProperties,
   primary: {
     display: 'inline-flex', alignItems: 'center', gap: 5, border: '1px solid transparent',
-    borderRadius: 8, padding: '6px 14px', background: C.accent, color: '#fff', cursor: 'pointer',
+    borderRadius: 8, padding: '6px 14px', background: `var(--kb-primary-bg, ${C.accent})`,
+    // DSH's brand-primary is near-BLACK in light but near-WHITE in dark; the
+    // foreground token inverts with the theme so the label stays readable on
+    // the accent fill in both modes (white text on white would vanish in dark).
+    color: 'var(--dsw-alias-label-primary-foreground, #fff)', cursor: 'pointer',
     fontSize: 13, fontWeight: 600,
   } as CSSProperties,
   primaryDanger: {
     display: 'inline-flex', alignItems: 'center', gap: 5, border: '1px solid transparent',
-    borderRadius: 8, padding: '6px 14px', background: C.danger, color: '#fff', cursor: 'pointer',
+    borderRadius: 8, padding: '6px 14px', background: `var(--kb-danger-bg, ${C.danger})`, color: 'var(--dsw-alias-label-primary-foreground, #fff)', cursor: 'pointer',
     fontSize: 13, fontWeight: 600,
   } as CSSProperties,
   danger: {
@@ -165,7 +235,8 @@ export const style = {
   empty: { color: C.muted, fontSize: 13, padding: 24, textAlign: 'center' } as CSSProperties,
   error: { color: C.danger, fontSize: 12, background: 'color-mix(in srgb, var(--dsw-alias-state-error-primary, #e5484d) 8%, transparent)', borderRadius: 8, padding: '8px 12px' } as CSSProperties,
   modalBackdrop: {
-    position: 'absolute', inset: 0, zIndex: 20, background: 'rgba(0,0,0,0.32)',
+    position: 'absolute', inset: 0, zIndex: 20, // Less transparent so dialog content stays clearly behind the modal.
+    background: 'rgba(0,0,0,0.58)',
     display: 'flex', alignItems: 'center', justifyContent: 'center',
   } as CSSProperties,
   modal: {
@@ -203,9 +274,14 @@ export const style = {
     display: 'flex', flexDirection: 'column', gap: 8, alignItems: 'center',
   } as CSSProperties,
   toast: {
-    display: 'flex', alignItems: 'center', gap: 8, borderRadius: 999, padding: '8px 16px',
+    display: 'flex', alignItems: 'center', gap: 8, borderRadius: 12, padding: '8px 14px',
     fontSize: 13, fontWeight: 600, background: C.overlay, border: `1px solid ${C.border}`,
-    boxShadow: '0 8px 24px rgba(0,0,0,0.14)', color: C.text,
+    boxShadow: '0 8px 24px rgba(0,0,0,0.14)', color: C.text, maxWidth: 'min(90vw, 560px)',
+  } as CSSProperties,
+  toastClose: {
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+    width: 20, height: 20, border: 'none', borderRadius: 999, background: 'transparent',
+    color: C.muted, cursor: 'pointer', padding: 0, marginLeft: 2,
   } as CSSProperties,
   fileRow: {
     display: 'flex', alignItems: 'center', gap: 8, border: `1px solid ${C.border}`,
@@ -214,10 +290,13 @@ export const style = {
   spinner: { display: 'inline-block', width: 14, height: 14, borderRadius: '50%', border: '2px solid currentColor', borderTopColor: 'transparent' } as CSSProperties,
   menu: {
     position: 'absolute', zIndex: 30, minWidth: 180, borderRadius: 10, padding: 4,
-    background: C.overlay, border: `1px solid ${C.border}`, boxShadow: '0 10px 32px rgba(0,0,0,0.18)',
+    // Opaque overlay surface (never translucent) with the stronger border tier
+    // so the popover separates from the panel in both themes.
+    background: C.overlay, border: `1px solid ${C.borderStrong}`, boxShadow: '0 10px 32px rgba(0,0,0,0.22)',
+    color: C.text,
   } as CSSProperties,
   menuItem: {
-    display: 'flex', alignItems: 'center', gap: 8, width: '100%', border: 'none', background: 'transparent',
+    display: 'flex', alignItems: 'center', gap: 8, width: '100%', border: 'none', background: 'var(--kb-mibg, transparent)',
     borderRadius: 7, padding: '7px 10px', fontSize: 13, color: C.text, cursor: 'pointer', textAlign: 'left',
   } as CSSProperties,
   menuItemDanger: { color: C.danger } as CSSProperties,
@@ -233,7 +312,10 @@ export const style = {
   } as CSSProperties,
   switchOn: { background: C.accent } as CSSProperties,
   switchKnob: {
-    position: 'absolute', top: 2, left: 2, width: 16, height: 16, borderRadius: '50%', background: '#fff',
+    position: 'absolute', top: 2, left: 2, width: 16, height: 16, borderRadius: '50%',
+    // Contrasts with the accent track in both themes (near-black knob on the
+    // near-white accent in dark mode, near-white knob on dark accent in light).
+    background: 'var(--dsw-alias-label-primary-foreground, #fff)',
     transition: 'transform 0.15s',
   } as CSSProperties,
   accordionHeader: {
@@ -267,9 +349,14 @@ export const style = {
     cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
     color: '#fff', padding: 0, flexShrink: 0, fontSize: 11, lineHeight: 1,
   } as CSSProperties,
-  checkboxOn: { background: C.accent, borderColor: C.accent } as CSSProperties,
+  checkboxOn: {
+    background: C.accent, borderColor: C.accent,
+    color: 'var(--dsw-alias-label-primary-foreground, #fff)',
+  } as CSSProperties,
   sidePanelScrim: {
-    position: 'absolute', inset: 0, zIndex: 30, background: 'rgba(0,0,0,0.28)',
+    // Less transparent scrim so the drawer clearly separates from the
+    // panel behind it (nothing reads through).
+    position: 'absolute', inset: 0, zIndex: 30, background: 'rgba(0,0,0,0.58)',
     display: 'flex', justifyContent: 'flex-end',
   } as CSSProperties,
   sidePanel: {
@@ -302,15 +389,27 @@ export function formatSize(charCount: number): string {
   return `${(charCount / (1024 * 1024)).toFixed(2)} MB`
 }
 
-/** Compact relative time, Cherry Studio style (刚刚 / N 分钟前 / N 小时前…). */
-export function formatRelativeTime(timestamp: number, now: number = Date.now()): string {
+/**
+ * Compact relative time, locale-aware via the bound translate (the old
+ * implementation hardcoded Chinese “刚刚 / N 分钟前…” which leaked into the
+ * English UI). now is only overridable for tests.
+ */
+export function formatRelativeTime(
+  timestamp: number,
+  // Optional so the previous one-arg call keeps compiling on `main` until
+  // KnowledgeSection adopts the locale-aware signature in the feature branch.
+  // Narrow key union keeps it callable with the bound Translate
+  // ((key: KnowledgeKey) => string) while staying decoupled from locales.
+  t?: (key: 'timeJustNow' | 'timeMinutes' | 'timeHours' | 'timeDays') => string,
+  now: number = Date.now(),
+): string {
   const diff = Math.max(0, now - timestamp)
   const minutes = Math.floor(diff / 60000)
-  if (minutes < 1) return '刚刚'
-  if (minutes < 60) return `${minutes} 分钟前`
+  if (minutes < 1) return t !== undefined ? t('timeJustNow') : '刚刚'
+  if (minutes < 60) return t !== undefined ? t('timeMinutes').replace('{n}', String(minutes)) : `${minutes} 分钟前`
   const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours} 小时前`
+  if (hours < 24) return t !== undefined ? t('timeHours').replace('{n}', String(hours)) : `${hours} 小时前`
   const days = Math.floor(hours / 24)
-  if (days < 30) return `${days} 天前`
+  if (days < 30) return t !== undefined ? t('timeDays').replace('{n}', String(days)) : `${days} 天前`
   return new Date(timestamp).toLocaleDateString()
 }

--- a/src/ui/client/theme.ts
+++ b/src/ui/client/theme.ts
@@ -160,7 +160,7 @@ export const style = {
     overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
     fontFamily: "'JetBrains Mono', ui-monospace, 'SF Mono', Consolas, monospace",
   } as CSSProperties,
-  baseSourceEdit: { marginLeft: 'auto', flexShrink: 0 } as CSSProperties,
+  baseSourceEdit: { flexShrink: 0 } as CSSProperties,
   main: { flex: 1, minWidth: 0, overflowY: 'auto', padding: 18, display: 'flex', flexDirection: 'column', gap: 14 } as CSSProperties,
   card: { border: `1px solid ${C.border}`, borderRadius: 12, background: C.surface, padding: 14, position: 'relative' } as CSSProperties,
   cardTitle: { fontSize: 13, fontWeight: 600, margin: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between' } as CSSProperties,

--- a/tests/domain-store.spec.ts
+++ b/tests/domain-store.spec.ts
@@ -844,7 +844,7 @@ describe('local-path import source tracking', () => {
 
         // Repoint the source to a different file and reindex: the reindex must
         // rebuild from the NEW path (previously it re-read the old raw copy).
-        await service.setBaseSourcePath(base.id, src2)
+        await service.setBaseSourcePath(base.id, doc!.id, src2)
         await service.reindexDocument(doc!.id)
         const reindexed = store.getDocument(doc!.id)
         expect(reindexed).toBeDefined()
@@ -866,7 +866,7 @@ describe('local-path import source tracking', () => {
         expect(dDoc).toBeDefined()
         const src3 = join(dir, 'e.txt')
         await writeFile(src3, 'epsilon content', 'utf8')
-        await service.setBaseSourcePath(base.id, src3)    // a FILE path now repoints files
+        await service.setBaseSourcePath(base.id, dDoc!.id, src3)
         await service.reindexDocument(dDoc!.id)
         expect(store.getDocument(dDoc!.id)!.rawText).toContain('epsilon')
         // The directory root was NOT touched by the file repoint.
@@ -923,6 +923,169 @@ describe('local-path import source tracking', () => {
         expect(remaining).toHaveLength(1)
         const survivor = store.listDocuments(base.id).filter(d => d.sourceType === 'file')[0]
         expect(decode(await store.raw!.read(survivor.rawFilePath!))).toContain('B')
+      } finally {
+        await closeStore(service)
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('repoints exactly one selected top-level source', async () => {
+    const dir = await tempDir()
+    try {
+      vi.stubEnv('DSH_HOME', dir)
+      const first = join(dir, 'first.txt')
+      const second = join(dir, 'second.txt')
+      const replacement = join(dir, 'replacement.txt')
+      await writeFile(first, 'first source', 'utf8')
+      await writeFile(second, 'second source', 'utf8')
+      await writeFile(replacement, 'replacement source', 'utf8')
+
+      const service = await mount(dir)
+      try {
+        const base = await service.createBase({ name: 'targeted' })
+        await service.importFromPath(base.id, first)
+        await service.importFromPath(base.id, second)
+        const store = storeOf(service)
+        const firstDoc = store.listDocuments(base.id).find(doc => doc.sourcePath === first)!
+        const secondDoc = store.listDocuments(base.id).find(doc => doc.sourcePath === second)!
+
+        await expect(service.setBaseSourcePath(base.id, firstDoc.id, replacement))
+          .resolves.toEqual({ set: 1 })
+        expect(store.getDocument(firstDoc.id)?.sourcePath).toBe(replacement)
+        expect(store.getDocument(secondDoc.id)?.sourcePath).toBe(second)
+        expect(service.listBases().find(row => row.id === base.id)?.sourceInfo).toEqual([
+          expect.objectContaining({ sourceId: firstDoc.id, sourcePath: replacement }),
+          expect.objectContaining({ sourceId: secondDoc.id, sourcePath: second }),
+        ])
+      } finally {
+        await closeStore(service)
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('validates source identity, top-level ownership, path kind, and absolute paths', async () => {
+    const dir = await tempDir()
+    try {
+      vi.stubEnv('DSH_HOME', dir)
+      const root = join(dir, 'root')
+      const file = join(dir, 'file.txt')
+      await mkdir(root, { recursive: true })
+      await writeFile(join(root, 'child.txt'), 'nested child', 'utf8')
+      await writeFile(file, 'top level file', 'utf8')
+
+      const service = await mount(dir)
+      try {
+        const base = await service.createBase({ name: 'validation' })
+        const other = await service.createBase({ name: 'other' })
+        await service.importFromPath(base.id, root)
+        await service.importFromPath(other.id, file)
+        const textDoc = await service.addTextDocument({ baseId: base.id, title: 'note', content: 'manual note' })
+        const store = storeOf(service)
+        const directoryRoot = store.listDocuments(base.id).find(doc => doc.sourceType === 'directory' && doc.parentDirectoryId === undefined)!
+        const nestedFile = store.listDocuments(base.id).find(doc => doc.sourceType === 'file')!
+        const otherFile = store.listDocuments(other.id).find(doc => doc.sourceType === 'file')!
+
+        await expect(service.importFromPath(base.id, '.')).rejects.toThrow(/absolute/i)
+        await expect(service.setBaseSourcePath(base.id, directoryRoot.id, '.')).rejects.toThrow(/absolute/i)
+        await expect(service.setBaseSourcePath(base.id, directoryRoot.id, file)).rejects.toThrow(/directory/i)
+        await expect(service.setBaseSourcePath(base.id, nestedFile.id, file)).rejects.toThrow(/top-level/i)
+        await expect(service.setBaseSourcePath(base.id, otherFile.id, file)).rejects.toThrow(/does not belong/i)
+        await expect(service.setBaseSourcePath(base.id, textDoc.id, file)).rejects.toThrow(/file or directory source/i)
+      } finally {
+        await closeStore(service)
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('uses the new file identity when a source is repointed across extensions', async () => {
+    const dir = await tempDir()
+    try {
+      vi.stubEnv('DSH_HOME', dir)
+      const original = join(dir, 'original.txt')
+      const replacement = join(dir, 'replacement.html')
+      await writeFile(original, 'plain original', 'utf8')
+      await writeFile(replacement, '<html><body><h1>Replacement</h1><p>HTML body</p></body></html>', 'utf8')
+
+      const service = await mount(dir)
+      try {
+        const base = await service.createBase({ name: 'parser identity' })
+        await service.importFromPath(base.id, original)
+        const store = storeOf(service)
+        const doc = store.listDocuments(base.id).find(row => row.sourceType === 'file')!
+
+        await service.setBaseSourcePath(base.id, doc.id, replacement)
+        await service.reindexDocument(doc.id)
+
+        const updated = store.getDocument(doc.id)!
+        expect(updated.fileName).toBe('replacement.html')
+        expect(updated.rawText).toContain('Replacement')
+        expect(updated.rawText).not.toContain('<h1>')
+        expect(updated.mimeType).toBeUndefined()
+      } finally {
+        await closeStore(service)
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps the previous raw copy when reindex fails before the new document commits', async () => {
+    const dir = await tempDir()
+    try {
+      vi.stubEnv('DSH_HOME', dir)
+      const original = join(dir, 'original.txt')
+      const replacement = join(dir, 'replacement.txt')
+      await writeFile(original, 'stable original bytes', 'utf8')
+      await writeFile(replacement, 'candidate replacement bytes', 'utf8')
+
+      const service = await mount(dir)
+      try {
+        const base = await service.createBase({ name: 'failure safe' })
+        await service.importFromPath(base.id, original)
+        const store = storeOf(service)
+        const doc = store.listDocuments(base.id).find(row => row.sourceType === 'file')!
+        const previousRaw = doc.rawFilePath!
+        await service.setBaseSourcePath(base.id, doc.id, replacement)
+
+        const putChunks = vi.spyOn(store, 'putChunks').mockRejectedValueOnce(new Error('simulated chunk commit failure'))
+        await expect(service.reindexDocument(doc.id)).rejects.toThrow('simulated chunk commit failure')
+        putChunks.mockRestore()
+
+        const failed = store.getDocument(doc.id)!
+        expect(failed.rawFilePath).toBe(previousRaw)
+        expect(decode(await store.raw!.read(previousRaw))).toContain('stable original bytes')
+        expect(await store.raw!.listAll()).toEqual([previousRaw])
+      } finally {
+        await closeStore(service)
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns per-file errors from a partial directory path import', async () => {
+    const dir = await tempDir()
+    try {
+      vi.stubEnv('DSH_HOME', dir)
+      const source = join(dir, 'partial')
+      await mkdir(source, { recursive: true })
+      await writeFile(join(source, 'good.txt'), 'readable content', 'utf8')
+      await writeFile(join(source, 'broken.pptx'), new Uint8Array([1, 2, 3, 4]))
+
+      const service = await mount(dir)
+      try {
+        const base = await service.createBase({ name: 'partial import' })
+        const result = await service.importFromPath(base.id, source)
+        expect(result.kind).toBe('directory')
+        expect(result.imported).toBe(1)
+        expect(result.errors).toHaveLength(1)
+        expect(result.errors[0]?.file).toContain('broken.pptx')
       } finally {
         await closeStore(service)
       }

--- a/tests/domain-store.spec.ts
+++ b/tests/domain-store.spec.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { Domain, KvTable } from '@deepseek-ai/dsh-storage-domain'
 import { Context } from '@deepseek-ai/cordis'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { knowledgeDomainSpec } from '../src/knowledge/domain.js'
 import { ChunkDatabase, hashEmbeddingText, migrateLegacyChunkFile } from '../src/knowledge/chunkdb.js'
 import { openStore } from '../src/knowledge/store.js'
-import type { StorageDomainFacility } from '../src/knowledge/store.js'
+import type { StorageDomainFacility, Store } from '../src/knowledge/store.js'
 import { KnowledgeService } from '../src/knowledge/index.js'
 import type { Config } from '../src/knowledge/config.js'
 import type { KnowledgeChunk } from '../src/knowledge/types.js'
@@ -800,6 +800,111 @@ describe('KnowledgeService restart', () => {
         expect(service2.getConfig().localModelCacheDir).toBe(resolve(modelsDir))
       } finally {
         await closeStore(service2)
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('local-path import source tracking', () => {
+  const decode = (bytes: Uint8Array | null): string => bytes !== null ? new TextDecoder().decode(bytes) : ''
+  const mount = async (dir: string): Promise<KnowledgeService> => {
+    const ctx = new Context()
+    ctx.provide('webServer', { routes: [], register: () => () => {} })
+    ctx.provide('storageDomain', { open: async () => fakeDomain() })
+    await ctx.plugin(KnowledgeService, { ...TEST_CONFIG, chunkStorePath: join(dir, 'chunks.sqlite') })
+    return ctx.get('knowledge') as KnowledgeService
+  }
+  const closeStore = async (service: KnowledgeService): Promise<void> => {
+    await (service as unknown as { store: { close(): Promise<void> } }).store.close()
+  }
+  const storeOf = (service: KnowledgeService): Store =>
+    (service as unknown as { store: Store }).store
+
+  it('reindexes a single-file path import from the repointed sourcePath', async () => {
+    const dir = await tempDir()
+    try {
+      vi.stubEnv('DSH_HOME', dir)
+      const src1 = join(dir, 'a.txt')
+      const src2 = join(dir, 'b.txt')
+      await writeFile(src1, 'alpha content', 'utf8')
+      await writeFile(src2, 'beta content', 'utf8')
+
+      const service = await mount(dir)
+      try {
+        const base = await service.createBase({ name: 'src' })
+        await service.importFromPath(base.id, src1)
+        const store = storeOf(service)
+        const doc = store.listDocuments(base.id).find(d => d.sourceType === 'file')
+        expect(doc).toBeDefined()
+        expect(doc!.rawText).toContain('alpha')
+        expect(doc!.sourcePath).toBe(src1)
+        const beforeHash = doc!.contentHash
+
+        // Repoint the source to a different file and reindex: the reindex must
+        // rebuild from the NEW path (previously it re-read the old raw copy).
+        await service.setBaseSourcePath(base.id, src2)
+        await service.reindexDocument(doc!.id)
+        const reindexed = store.getDocument(doc!.id)
+        expect(reindexed).toBeDefined()
+        expect(reindexed!.rawText).toContain('beta')
+        expect(reindexed!.contentHash).not.toBe(beforeHash)
+        expect(reindexed!.sourcePath).toBe(src2)
+        // The persisted raw copy was refreshed to the new file's bytes.
+        expect(decode(await store.raw!.read(reindexed!.rawFilePath!))).toContain('beta')
+      } finally {
+        await closeStore(service)
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps raw copies distinct when two directory roots share a relative path', async () => {
+    const dir = await tempDir()
+    try {
+      vi.stubEnv('DSH_HOME', dir)
+      const rootA = join(dir, 'rootA')
+      const rootB = join(dir, 'rootB')
+      await mkdir(join(rootA, 'docs'), { recursive: true })
+      await mkdir(join(rootB, 'docs'), { recursive: true })
+      await writeFile(join(rootA, 'docs', 'report.txt'), 'report from A', 'utf8')
+      await writeFile(join(rootB, 'docs', 'report.txt'), 'report from B', 'utf8')
+
+      const service = await mount(dir)
+      try {
+        const base = await service.createBase({ name: 'collide' })
+        await service.importFromPath(base.id, rootA)
+        await service.importFromPath(base.id, rootB)
+        const store = storeOf(service)
+        const docs = store.listDocuments(base.id).filter(d => d.sourceType === 'file')
+        expect(docs).toHaveLength(2)
+
+        // Both files share the relative path docs/report.txt, but each must own
+        // a distinct raw copy whose bytes match its own source (no collision).
+        const raws = new Set<string>()
+        const contents: string[] = []
+        for (const doc of docs) {
+          expect(doc.rawFilePath).toBeDefined()
+          raws.add(doc.rawFilePath!)
+          contents.push(decode(await store.raw!.read(doc.rawFilePath!)))
+        }
+        expect(raws.size).toBe(2)
+        expect(contents).toEqual(expect.arrayContaining(['report from A', 'report from B']))
+
+        // Removing report.txt from rootA and rescanning rootA must delete A's
+        // doc and its raw copy, but leave rootB's cached raw untouched.
+        await rm(join(rootA, 'docs', 'report.txt'))
+        const rootAId = store.listDocuments(base.id)
+          .find(d => d.sourceType === 'directory' && d.title === 'rootA')!.id
+        await service.reindexDocument(rootAId)
+        const remaining = store.listDocuments(base.id).filter(d => d.sourceType === 'file')
+        expect(remaining).toHaveLength(1)
+        const survivor = store.listDocuments(base.id).filter(d => d.sourceType === 'file')[0]
+        expect(decode(await store.raw!.read(survivor.rawFilePath!))).toContain('B')
+      } finally {
+        await closeStore(service)
       }
     } finally {
       await rm(dir, { recursive: true, force: true })

--- a/tests/domain-store.spec.ts
+++ b/tests/domain-store.spec.ts
@@ -853,6 +853,26 @@ describe('local-path import source tracking', () => {
         expect(reindexed!.sourcePath).toBe(src2)
         // The persisted raw copy was refreshed to the new file's bytes.
         expect(decode(await store.raw!.read(reindexed!.rawFilePath!))).toContain('beta')
+
+        // Mixed-base repoint: with a directory root present, a FILE repoint must
+        // still select the top-level files (not the directories).
+        const mixed = join(dir, 'mixed')
+        await mkdir(join(mixed, 'sub'), { recursive: true })
+        await writeFile(join(mixed, 'sub', 'c.txt'), 'c content', 'utf8')
+        await writeFile(join(dir, 'd.txt'), 'delta content', 'utf8')
+        await service.importFromPath(base.id, mixed)      // adds a directory root
+        await service.importFromPath(base.id, join(dir, 'd.txt')) // adds a top-level file
+        const dDoc = store.listDocuments(base.id).find(d => d.sourceType === 'file' && d.fileName === 'd.txt')
+        expect(dDoc).toBeDefined()
+        const src3 = join(dir, 'e.txt')
+        await writeFile(src3, 'epsilon content', 'utf8')
+        await service.setBaseSourcePath(base.id, src3)    // a FILE path now repoints files
+        await service.reindexDocument(dDoc!.id)
+        expect(store.getDocument(dDoc!.id)!.rawText).toContain('epsilon')
+        // The directory root was NOT touched by the file repoint.
+        const dirRoot = store.listDocuments(base.id).find(d => d.sourceType === 'directory')
+        expect(dirRoot).toBeDefined()
+        expect(dirRoot!.sourcePath).toBe(mixed)
       } finally {
         await closeStore(service)
       }

--- a/tests/embed.spec.ts
+++ b/tests/embed.spec.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { embedTexts } from '../src/knowledge/embed.js'
+
+describe('embedding provider URL defaults', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses the local Ollama endpoint when the configured base URL is empty', async () => {
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => new Response(JSON.stringify({ embeddings: [[0.25, 0.75]] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const vectors = await embedTexts('ollama', '   ', 'nomic-embed-text', '', ['hello'])
+    expect(vectors[0]?.[0]).toBeCloseTo(0.316227766)
+    expect(vectors[0]?.[1]).toBeCloseTo(0.948683298)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('http://127.0.0.1:11434/api/embed')
+  })
+
+  it('continues to reject an empty OpenAI-compatible base URL', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(embedTexts('openai', ' ', 'text-embedding-3-small', '', ['hello']))
+      .rejects.toThrow('embedding base URL is empty')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/popover-placement.spec.ts
+++ b/tests/popover-placement.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { placePopover, placeSubmenu } from '../src/ui/client/popover-placement.js'
+
+describe('popover placement', () => {
+  const viewport = { width: 800, height: 600 }
+
+  it('keeps a top-level menu inside the viewport and flips above the trigger', () => {
+    expect(placePopover(
+      { top: 560, right: 790, bottom: 584, left: 750 },
+      { width: 180, height: 160 },
+      viewport,
+      'end',
+    )).toEqual({ top: 396, left: 610 })
+  })
+
+  it('opens a submenu beside its parent and flips to the left near the right edge', () => {
+    expect(placeSubmenu(
+      { top: 120, right: 790, bottom: 156, left: 610 },
+      { width: 180, height: 240 },
+      viewport,
+    )).toEqual({ top: 120, left: 426 })
+  })
+
+  it('clamps oversized placements to the viewport margin', () => {
+    expect(placeSubmenu(
+      { top: 580, right: 110, bottom: 616, left: 10 },
+      { width: 900, height: 700 },
+      viewport,
+    )).toEqual({ top: 8, left: 8 })
+  })
+})

--- a/tests/ui-policy.spec.ts
+++ b/tests/ui-policy.spec.ts
@@ -1,0 +1,27 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+
+async function source(path: string): Promise<string> {
+  return readFile(new URL(`../src/ui/client/${path}`, import.meta.url), 'utf8')
+}
+
+describe('knowledge UI policy', () => {
+  it('keeps Ollama model browsing separate from embedding configuration', async () => {
+    const models = await source('LocalModelsSection.tsx')
+
+    // This page still has explicit save controls for the cache, mirror, and
+    // worker timeout. It must not persist embedding selection as a side effect
+    // of listing or pulling Ollama models.
+    expect(models).not.toContain('persistOllamaDefault')
+    expect(models).not.toMatch(/embeddingProvider\s*:/)
+    expect(models).not.toMatch(/embeddingBaseUrl\s*:/)
+    expect(models).not.toMatch(/embeddingModel\s*:/)
+  })
+
+  it('wires toast dismissal into panel state', async () => {
+    const panel = await source('KnowledgeSection.tsx')
+
+    expect(panel).toContain('<Toasts toasts={toasts} onDismiss={dismissToast} />')
+    expect(panel).toMatch(/setToasts\(prev => prev\.filter\(toast => toast\.id !== id\)\)/)
+  })
+})


### PR DESCRIPTION
## Summary

This maintainer integration combines the related community work from #10, #11, #12, and #13 on top of v0.3.8:

- Ollama empty-URL fallback
- Chinese and English locale additions
- local file/directory path import and source tracking
- theme, toast, and popover interaction improvements

## Maintainer hardening

The combined branch adds regression coverage and addresses the integration issues found during review:

- source-path edits target one explicit top-level source instead of sibling roots
- cross-base, nested, relative, and type-mismatched source targets are rejected
- cross-extension source changes use the new parser identity
- failed reindex keeps the previous raw copy and removes only the staged candidate
- partial directory-import errors are returned to the UI
- Ollama browsing/pulling no longer changes embedding configuration implicitly
- root and nested popovers stay within the viewport
- UI policy tests protect toast dismissal and explicit model configuration

## Attribution

The original contributor commits and author identity from @ThinkForge-core are preserved in the commit history. Maintainer fixes and tests are separate commits for reviewability.

## Verification

- [x] TypeScript typecheck
- [x] 25 Vitest files / 322 tests
- [x] retrieval benchmark v2: Hit@1, Hit@3, Visible Evidence, and Bridge@1 all 100%
- [x] build
- [x] release metadata verification
- [x] npm package verification
- [x] production dependency audit
- [x] Windows packed DSH install/boot/remove smoke

This PR does not change the package version, create a tag, or publish npm.